### PR TITLE
Adiciona ResourceExpended signal

### DIFF
--- a/Scripts/Entities/UI/AddCommunist.cs
+++ b/Scripts/Entities/UI/AddCommunist.cs
@@ -37,8 +37,8 @@ public partial class AddCommunist : Button
 		//INICIA SPAWN DOS GATOS CAMPONESES
 		ResourceSpawnTimer = GetTree().CreateTimer(SpawnTimer);
 
-		if (LevelManager.SalmonQuantity >= 100)
-		{
+		if (LevelManager.SalmonQuantity >= 100){
+			LevelManager.EmitSignal(LevelManager.SignalName.ResourceExpended, Constants.SALMON, 100);
 			ResourceSpawnTimer.Timeout += delegate
 			{
 				addCommunist.GlobalPosition = purrlamentNode.GlobalPosition + _communistPosition;

--- a/Scripts/Systems/LevelManager.cs
+++ b/Scripts/Systems/LevelManager.cs
@@ -6,6 +6,9 @@ public partial class LevelManager : Node2D
 	[Signal]
 	public delegate void ResourceDeliveredEventHandler(string resource, int quantity);
 	
+	[Signal]
+	public delegate void ResourceExpendedEventHandler(string resource, int quantity);
+	
 	// VARIAVEIS DE QUANTIDADE DE RECURSO ATUAL
 	[Export] public int CatnipQuantity = 0;
 	[Export] public int SalmonQuantity = 0;
@@ -29,9 +32,26 @@ public partial class LevelManager : Node2D
 		SalmonLabel = ResCount.GetNode<Label>("SalmonLabel");
 		SandLabel = ResCount.GetNode<Label>("SandLabel");
 		ResourceDelivered += When_resource_delivered;
+		ResourceExpended += WhenResourceExpended;
 		CatnipLabel.Text = $"{CatnipQuantity}";
 		SalmonLabel.Text = $"{SalmonQuantity}";
 		SandLabel.Text = $"{SandQuantity}";
+	}
+	private void WhenResourceExpended(string resource, int quantity){
+		switch (resource){
+			case Constants.CATNIP:
+				CatnipQuantity -= quantity;
+				CatnipLabel.Text = $"{CatnipQuantity}";
+				break;
+			case Constants.SALMON:
+				SalmonQuantity -= quantity;
+				SalmonLabel.Text = $"{SalmonQuantity}";
+				break;
+			case Constants.SAND:
+				SandQuantity -= quantity;
+				SandLabel.Text = $"{SandQuantity}";
+				break;
+		}
 	}
 
 	public void When_resource_delivered(string resource, int quantity){

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_eesl2"]
+[sub_resource type="Resource" id="Resource_6mp6r"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -51,7 +51,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_eesl2")
+Data = SubResource("Resource_6mp6r")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)


### PR DESCRIPTION
Implementa um sinal para quando um recurso for gasto dentro de LevelManager.

Utilização:

`LevelManager.EmitSignal(LevelManager.SignalName.ResourceExpended, Constants.SALMON, 100);`

A função:

`LevelManager `-> Referência ao node LevelManager.
`EmitSignal` -> Emissão de um sinal
`LevelManager.SignalName.ResourceExpended` -> O nome interno do signal gerado pelo C++ da Godot.


As funções de EmitSignal usam argumentos baseados no Signal que você quer chamar. Nesse caso:

`[Signal] public delegate void ResourceExpendedEventHandler(string resource, int quantity);`

Por isso eu passo no EmitSignal o `Constants.SALMON` e depois `100`, que indica qual o recurso está sendo gasto, e sua quantidade.

Para gastar mais de um recurso de uma vez, chamar o EmitSignal mais de uma vez com parâmetros diferentes.