### PR TITLE
32 - [BUG] Corrigir seleção de construções

### DIFF
--- a/Resources/Buildings/GreatCommune/GreatCommune.tres
+++ b/Resources/Buildings/GreatCommune/GreatCommune.tres
@@ -22,3 +22,4 @@ Hp = 10000
 NeedsRegion = true
 RegionRect = Rect2(179, 163, 287, 215)
 MaxProgress = 0
+IsPreSpawned = true

--- a/Scripts/BuildingDebug.cs
+++ b/Scripts/BuildingDebug.cs
@@ -1,0 +1,15 @@
+using Godot;
+using System;
+
+public partial class BuildingDebug : Label
+{
+	// Called when the node enters the scene tree for the first time.
+	public override void _Ready()
+	{
+	}
+
+	// Called every frame. 'delta' is the elapsed time since the previous frame.
+	public override void _Process(double delta)
+	{
+	}
+}

--- a/Scripts/Entities/Building/Building.cs
+++ b/Scripts/Entities/Building/Building.cs
@@ -1,31 +1,34 @@
+using ClawtopiaCs.Scripts.Entities.Building;
+using ClawtopiaCs.Scripts.Systems;
 using Godot;
 using Godot.Collections;
 
 public partial class Building : Area2D
 {
-
     [Signal]
     public delegate void AboutToInteractEventHandler(Building self);
+
     [Signal]
-    public delegate void RemovedInteractionEventHandler();
-    
+    public delegate void RemovedInteractionEventHandler(Building self);
+
     public Color OkColor = new Color("2eff3f81");
     public Color ErrorColor = new Color("ba000079");
     public Color RegularColor = new Color(1, 1, 1);
     public Color HoverColor = new Color(1.3f, 1.3f, 1.3f);
-    
+
     public NavigationRegion2D Region;
     public SimulationMode SimulationMode;
     public BuildMode BuildingMode;
     public ModeManager ModeManager;
     public LevelManager LevelManager;
-    
+
     public int SelfIndex;
     public bool Placed;
     public bool IsBuilt;
-    
+
     // TIMER PARA TICK DE TEMPO DE CONSTRUCAO
     public SceneTreeTimer BuildTickTimer;
+
     // TEMPO EM SEGUNDOS POR TICK
     public float TickTime = 1.0f;
     public int Progress;
@@ -41,19 +44,22 @@ public partial class Building : Area2D
     [Export] public Sprite2D Sprite;
 
     public string ResourceType;
+    public bool IsBuildingInFront;
 
-
-    public override void _Ready() {
+    public override void _Ready()
+    {
         Initialize();
     }
-    
-    public void Initialize() {
+
+    public void Initialize()
+    {
+        IsPreSpawned = Data.IsPreSpawned;
         ModeManager = GetNode<ModeManager>("/root/Game/ModeManager");
         BuildingMode = GetNode<BuildMode>("/root/Game/ModeManager/BuildMode");
         Region = GetNode<NavigationRegion2D>("../Navigation");
         StaticBody = GetNode<StaticBody2D>("NavigationBody");
         SimulationMode = GetNode<SimulationMode>("/root/Game/ModeManager/SimulationMode");
-        LevelManager = GetNode<LevelManager>("/root/Game/LevelManager");
+        LevelManager = GetNode<ClawtopiaCs.Scripts.Systems.LevelManager>("/root/Game/LevelManager");
         Data.Initialize();
         BodyShape.Polygon = Data.ObstacleShape.Segments;
         InteractionShape.Polygon = Data.InteractionShape.Segments;
@@ -63,27 +69,31 @@ public partial class Building : Area2D
         Sprite.Offset = Data.Offset;
         Sprite.Scale = Data.Scale;
         Sprite.RegionEnabled = false;
-        if (Data.NeedsRegion){
+        if (Data.NeedsRegion) {
             Sprite.RegionEnabled = true;
             Sprite.RegionRect = Data.RegionRect;
         }
+
         Name = Data.Name + "_" + Data.Type + "_" + SelfIndex;
-        if (Data.Type.Equals(Constants.COMMUNE)){
+        if (Data.Type.Equals(Constants.COMMUNE)) {
             Name = Constants.COMMUNE_EXTERNAL_NAME;
         }
-        if(Data.Type == Constants.HOUSE){
+
+        if (Data.Type == Constants.HOUSE) {
             Name = Constants.HOUSE_EXTERNAL_NAME;
         }
-        if(Data.Type == Constants.TOWER){
-            switch(Data.TowerType){
+
+        if (Data.Type == Constants.TOWER) {
+            switch (Data.TowerType) {
                 case Constants.FIGHTERS:
                     Name = Constants.FIGHTERS_TOWER_EXTERNAL_NAME;
                     break;
                 /*todo implementar o resto*/
             }
         }
-        if(Data.Type == Constants.RESOURCE){
-            switch(Data.ResourceType){
+
+        if (Data.Type == Constants.RESOURCE) {
+            switch (Data.ResourceType) {
                 case Constants.SALMON:
                     Name = Constants.FISHERMAN_HOUSE_EXTERNAL_NAME;
                     break;
@@ -95,16 +105,22 @@ public partial class Building : Area2D
                     break;
             }
         }
-        MaxProgress = Data.MaxProgress;
+
+        MaxProgress = OS.IsDebugBuild() ? 3 : Data.MaxProgress;
         Region.BakeFinished += FreeToRebake;
         AboutToInteract += SimulationMode.AboutToInteractWithBuilding;
         RemovedInteraction += SimulationMode.InteractionWithBuildingRemoved;
         BuildingMode.ConstructionStarted += ConstructionStarted;
         CallDeferred("AddSelfOnList");
+        if (!IsPreSpawned) {
+            return;
+        }
+        IsBuilt = true;
     }
 
-    public void AddSelfOnList(){
-        switch (Data.ResourceType){
+    public void AddSelfOnList()
+    {
+        switch (Data.ResourceType) {
             case Constants.SALMON:
                 ResourceType = Constants.SALMON;
                 LevelManager.SalmonBuildings.Add(this);
@@ -117,11 +133,12 @@ public partial class Building : Area2D
                 ResourceType = Constants.SAND;
                 LevelManager.SandBuildings.Add(this);
                 break;
-        }   
+        }
     }
 
-    public void RemoveSelfFromList(){
-        switch (Data.ResourceType){
+    public void RemoveSelfFromList()
+    {
+        switch (Data.ResourceType) {
             case Constants.SALMON:
                 LevelManager.SalmonBuildings.Remove(this);
                 break;
@@ -134,25 +151,24 @@ public partial class Building : Area2D
         }
     }
 
-    public void SetRebake() {
+    public void SetRebake()
+    {
         StaticBody.Name = "Obstacle_Region_" + Data.Type + "_" + SelfIndex;
         StaticBody.Reparent(Region);
         ModeManager.CurrentlyBaking = true;
     }
 
-    public void RebakeAddBuilding() {
-        if (IsPreSpawned) {
-            SetRebake();
-            IsBuilt = true;
+    public void RebakeAddBuilding(bool initialize = false)
+    {
+        if (ModeManager.CurrentMode is not BuildMode && !initialize) {
             return;
         }
-        if (ModeManager.CurrentMode is BuildMode) {
-            SetRebake();
-            return;
-        }
+
+        SetRebake();
     }
 
-    public void RebakeRemoveBuilding() {
+    public void RebakeRemoveBuilding()
+    {
         if (!ModeManager.CurrentlyBaking) {
             StaticBody2D obstacle = Region.GetNode<StaticBody2D>("Obstacle_Region_" + Data.Type + "_" + SelfIndex);
             obstacle.Reparent(this);
@@ -161,58 +177,87 @@ public partial class Building : Area2D
         }
     }
 
-    public void Rebake(){
+    public void Rebake()
+    {
         Region.BakeNavigationPolygon();
     }
 
-    public void FreeToRebake() {
+    public void FreeToRebake()
+    {
         ModeManager.CurrentlyBaking = false;
         Placed = true;
-        if(ModeManager.BuildingsToBake.Count > 0) {
+        if (ModeManager.BuildingsToBake.Count > 0) {
             ModeManager.BuildingsToBake[0].RebakeAddBuilding();
             ModeManager.BuildingsToBake[0].Rebake();
             ModeManager.BuildingsToBake.RemoveAt(0);
         }
     }
 
-    public void ConstructionStarted(Building building){
+    public void ConstructionStarted(Building building)
+    {
         // if (IsBuilt){ return; }
         Progress = 0;
         BuildTickTimer = GetTree().CreateTimer(TickTime, false);
         BuildTickTimer.Timeout += ConstructionTimeElapsed;
     }
-    public void ConstructionTimeElapsed(){
+
+    public void ConstructionTimeElapsed()
+    {
         // if (IsBuilt){ return; }
         var nextProgress = Progress + CurrentBuilders.Count;
-        if (nextProgress < MaxProgress){
+        if (nextProgress < MaxProgress) {
             Progress = nextProgress;
             BuildTickTimer = GetTree().CreateTimer(TickTime);
             BuildTickTimer.Timeout += ConstructionTimeElapsed;
             return;
         }
+
         BuildingMode.EmitSignal("BuildCompleted", this);
         IsBuilt = true;
         BuildTickTimer.Timeout -= ConstructionTimeElapsed;
     }
 
-    public override void _MouseEnter(){
-        if (ModeManager.CurrentMode is SimulationMode){
-            Modulate = IsBuilt ? HoverColor : OkColor;
-            if (SimulationMode.SelectedAllies.Count > 0){
-                EmitSignal("AboutToInteract", this);
-            }
-        }
-    }
-    public override void _MouseExit(){
-        if (ModeManager.CurrentMode is SimulationMode){
-            Modulate = IsBuilt ? RegularColor : OkColor;
-            if (SimulationMode.SelectedAllies.Count > 0){
-                EmitSignal("RemovedInteraction");
-            }
+    public override void _MouseEnter()
+    {
+        if (ModeManager.CurrentMode is not global::SimulationMode) { return; }
+
+        if (SimulationMode.BuildingsToInteract.Count == 0 || SimulationMode.BuildingsToInteract[0] != this) {
+            EmitSignal("AboutToInteract", this);
+            GD.Print($"Mouse entered on {this.Name}");
         }
     }
 
-    public override void _ExitTree(){
+
+    public override void _MouseExit()
+    {
+        if (ModeManager.CurrentMode is not global::SimulationMode) { return; }
+        EmitSignal("RemovedInteraction", this);
+        GD.Print($"Mouse exited from {this.Name}");
+    }
+
+    public override void _ExitTree()
+    {
         RemoveSelfFromList();
     }
+
+    public static void ModulateBuilding(Building building, BuildingInteractionStates state)
+    {
+        switch (state) {
+            case BuildingInteractionStates.HOVER:
+                building.Modulate = building.IsBuilt ? building.HoverColor : building.OkColor;
+                break;
+            case BuildingInteractionStates.UNHOVER:
+                building.Modulate = building.IsBuilt ? building.RegularColor : building.OkColor;
+                break;
+            case BuildingInteractionStates.BUILDING_ERROR:
+                building.Modulate = building.ErrorColor;
+                break;
+            case BuildingInteractionStates.BUILDING_OK:
+                building.Modulate = building.OkColor;
+                break;
+            case BuildingInteractionStates.BUILD_FINISHED:
+                building.Modulate = building.RegularColor;
+                break;
+        }
+    } 
 }

--- a/Scripts/Entities/Building/BuildingData.cs
+++ b/Scripts/Entities/Building/BuildingData.cs
@@ -3,6 +3,8 @@ using System;
 
 public partial class BuildingData : Resource
 {
+    public const string PROP_ISBUILDING = "IsBuilding";
+    
     [Export] public Vector2 Offset;
     [Export] public Vector2 Scale = new (1,1);
     [Export] public Vector2 InteractionOffset;
@@ -17,6 +19,7 @@ public partial class BuildingData : Resource
     [Export] public bool NeedsRegion = false;
     [Export] public Rect2 RegionRect;
     [Export] public int MaxProgress;
+    [Export] public bool IsPreSpawned;
     public int Level;
     public String Name;
 

--- a/Scripts/Entities/Building/BuildingInteractionStates.cs
+++ b/Scripts/Entities/Building/BuildingInteractionStates.cs
@@ -1,0 +1,11 @@
+namespace ClawtopiaCs.Scripts.Entities.Building;
+
+public enum BuildingInteractionStates
+{
+    METADATA_ISBUILDING = 0,
+    HOVER,
+    UNHOVER,
+    BUILDING_ERROR,
+    BUILDING_OK,
+    BUILD_FINISHED,
+}

--- a/Scripts/Entities/Characters/Allies/Ally.cs
+++ b/Scripts/Entities/Characters/Allies/Ally.cs
@@ -22,14 +22,14 @@ public partial class Ally : Unit
     public Building ConstructionToBuild;
     
     // REFERENCIA PARA O LEVEL MANAGER, QUE TERÁ OS DADOS DE RECURSO DO JOGADOR
-    public LevelManager LevelManager;
+    public ClawtopiaCs.Scripts.Systems.LevelManager LevelManager;
     
     public override void _Ready(){
         CallDeferred("Initialize");
     }
 
     public void Initialize(){
-        LevelManager = GetNode<LevelManager>("/root/Game/LevelManager");
+        LevelManager = GetNode<ClawtopiaCs.Scripts.Systems.LevelManager>("/root/Game/LevelManager");
         CurrentLevel = LevelManager.GetNode<Node2D>("Level");
     }
 }

--- a/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
@@ -56,14 +56,14 @@ public partial class EconomicState : AllyState
         return closestBuildingPosition;
     }
     public void ChooseNextTargetPosition(Vector2 coords){
-        Ally.InteractedWithBuilding = SimulationMode.BuildingToInteract != null;
+        Ally.InteractedWithBuilding = SimulationMode.BuildingsToInteract.Count > 0;
         if (Ally.InteractedWithBuilding){
             Ally.Navigation.SetTargetPosition(
                 RecalculateCoords(
                     Ally.GlobalPosition,
-                    SimulationMode.BuildingToInteract.GlobalPosition
+                    SimulationMode.BuildingsToInteract[0].GlobalPosition
                 ));
-            Ally.InteractedBuilding = SimulationMode.BuildingToInteract;
+            Ally.InteractedBuilding = SimulationMode.BuildingsToInteract[0];
         }else if (IsInteractingWithWaterAt(coords)){
             Ally.InteractedResource = Constants.SALMON; // VARIAVEL NO ALIADO BASE PARA REFERENCIA
             Ally.InteractedBuilding = null;

--- a/Scripts/Entities/UI/AddCommunist.cs
+++ b/Scripts/Entities/UI/AddCommunist.cs
@@ -4,7 +4,7 @@ using System;
 public partial class AddCommunist : Button
 {
 	public ModeManager ModeManager;
-	public LevelManager LevelManager;
+	public ClawtopiaCs.Scripts.Systems.LevelManager LevelManager;
 	public UI Ui;
 	public SceneTreeTimer ResourceSpawnTimer;
     
@@ -31,14 +31,14 @@ public partial class AddCommunist : Button
 		GD.Print("SPAWN");
 
 		var addCommunist = _scene.Instantiate<Ally>();
-		var purrlamentNode = ModeManager.CurrentLevel.GetNode<Building>("Purrlamento");
-		LevelManager = GetNode<LevelManager>("/root/Game/LevelManager");
+		var purrlamentNode = ModeManager.CurrentLevel.GetNode<Building>(Constants.COMMUNE_EXTERNAL_NAME);
+		LevelManager = GetNode<ClawtopiaCs.Scripts.Systems.LevelManager>("/root/Game/LevelManager");
 
 		//INICIA SPAWN DOS GATOS CAMPONESES
 		ResourceSpawnTimer = GetTree().CreateTimer(SpawnTimer);
 
 		if (LevelManager.SalmonQuantity >= 100){
-			LevelManager.EmitSignal(LevelManager.SignalName.ResourceExpended, Constants.SALMON, 100);
+			LevelManager.EmitSignal(ClawtopiaCs.Scripts.Systems.LevelManager.SignalName.ResourceExpended, Constants.SALMON, 100);
 			ResourceSpawnTimer.Timeout += delegate
 			{
 				addCommunist.GlobalPosition = purrlamentNode.GlobalPosition + _communistPosition;

--- a/Scripts/Systems/GameModes/GameMode.cs
+++ b/Scripts/Systems/GameModes/GameMode.cs
@@ -2,6 +2,13 @@ using Godot;
 using System;
 
 public partial class GameMode : Node2D {
+
+    public enum Modes
+    {
+        BUILD_MODE = 0,
+        SIMULATION_MODE,
+    }
+    
     [Signal]
     public delegate void ModeTransitionEventHandler(String mode, String building, String type);
 
@@ -29,6 +36,8 @@ public partial class GameMode : Node2D {
 
     public virtual void MousePressed(Vector2 coords) { }
     public virtual void MouseReleased(Vector2 coords) { }
+    
+    public virtual void MouseRightPressed(Vector2 coords) { }
 
     public void Initialize(){
         //Director = GetNode<Director>("/root/Game/Director");
@@ -36,6 +45,9 @@ public partial class GameMode : Node2D {
         Controller = GetNode<Controller>("/root/Game/Controller");
         Controller.MousePressed += MousePressed;
         Controller.MouseReleased += MouseReleased;
+        Controller.MouseRightPressed += MouseRightPressed;
     }
+
+    
 }
 

--- a/Scripts/Systems/GameModes/ModeManager.cs
+++ b/Scripts/Systems/GameModes/ModeManager.cs
@@ -92,7 +92,7 @@ public partial class ModeManager : Node2D
                     GreatCommuneCount++;
                 }
                 BuildingsToBake.Add(building);
-                building.RebakeAddBuilding();
+                building.RebakeAddBuilding(true);
             }
         }
         Region = GetNode<NavigationRegion2D>("/root/Game/LevelManager/Level/Navigation");

--- a/Scripts/Systems/LevelManager.cs
+++ b/Scripts/Systems/LevelManager.cs
@@ -1,6 +1,8 @@
 using Godot;
 using Godot.Collections;
 
+namespace ClawtopiaCs.Scripts.Systems;
+
 public partial class LevelManager : Node2D
 {
 	[Signal]

--- a/Scripts/Systems/Selectors.cs
+++ b/Scripts/Systems/Selectors.cs
@@ -1,0 +1,95 @@
+using ClawtopiaCs.Scripts.Entities.Building;
+using Godot;
+using Godot.Collections;
+
+namespace ClawtopiaCs.Scripts.Systems;
+
+public partial class Selectors : Node2D
+{
+    private static Building SelectTopBuilding(Array<Area2D> overlappingAreas)
+    {
+        var buildingInFront = new Building();
+        foreach (var area in overlappingAreas) {
+            var isBuilding = area.GetParent().HasMeta(new StringName(BuildingData.PROP_ISBUILDING));
+            var hasHigherY = area.GlobalPosition.Y > buildingInFront.GlobalPosition.Y;
+            if (hasHigherY && isBuilding) {
+                buildingInFront = (Building)area.GetParent();
+            }
+        }
+
+        return buildingInFront;
+    }
+
+    public static void SelectSingleBuilding(Array<Area2D> overlappingAreas, UI ui)
+    {
+        var buildingInFront = SelectTopBuilding(overlappingAreas);
+        switch (buildingInFront.Data.Type) {
+            case Constants.COMMUNE:
+                ui.Instantiate_window(Constants.PURRLAMENT_MENU);
+                break;
+            default:
+                ui.Instantiate_window(Constants.BUILDING_MENU, buildingInFront);
+                break;
+        }
+    }
+
+    public static Ally SelectSingleUnit(Array<Area2D> overlappingAreas, UI ui)
+    {
+        var ally = SelectTopUnit(overlappingAreas);
+        
+        if (ally is null) {
+            return null;
+        }
+
+        ally.CurrentlySelected = true;
+        var selectionCircle = ally.GetNode<Line2D>("SelectionCircle");
+        selectionCircle.Visible = true;
+        ui.Instantiate_window(Constants.COMMUNIST_MENU);
+
+        return ally;
+    }
+
+    public static Array<Ally> SelectMultipleUnits(Array<Area2D> overlappingAreas, UI ui)
+    {
+        var selectedAllies = new Array<Ally>();
+        foreach (var area in overlappingAreas) {
+            if (area.GetParent() is not Ally ally) continue;
+            selectedAllies.Add(ally);
+            ally.CurrentlySelected = true;
+            var selectionCircle = ally.GetNode<Line2D>("SelectionCircle");
+            selectionCircle.Visible = true;
+        }
+
+        ui.Instantiate_window(Constants.COMMUNIST_MENU);
+        return selectedAllies;
+    }
+
+    public static Array<Ally> ClearSelectedAllies(Array<Ally> selectedAllies)
+    {
+        foreach (var ally in selectedAllies) {
+            ally.CurrentlySelected = false;
+            var selectionCircle = ally.GetNode<Line2D>("SelectionCircle");
+            selectionCircle.Visible = false;
+        }
+
+        selectedAllies.Clear();
+
+        return selectedAllies;
+    }
+
+    private static Ally SelectTopUnit(Array<Area2D> overlappingAreas)
+    {
+        var ally = new Ally();
+        foreach (var area in overlappingAreas) {
+            if (area.GetParent() is not Ally) {
+                continue;
+            }
+
+            if (area.GlobalPosition.Y > ally.GlobalPosition.Y) {
+                ally = (Ally)area.GetParent();
+            }
+        }
+
+        return ally;
+    }
+}

--- a/TSCN/Entities/Buildings/Building.tscn
+++ b/TSCN/Entities/Buildings/Building.tscn
@@ -9,6 +9,7 @@ BodyShape = NodePath("NavigationBody/Shape")
 InteractionShape = NodePath("InteractionShape")
 GridShape = NodePath("GridArea/Shape")
 Sprite = NodePath("Sprite2D")
+metadata/IsBuilding = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 region_rect = Rect2(179, 163, 287, 215)
@@ -17,8 +18,9 @@ region_rect = Rect2(179, 163, 287, 215)
 
 [node name="Shape" type="CollisionPolygon2D" parent="NavigationBody"]
 
-[node name="InteractionShape" type="CollisionPolygon2D" parent="."]
-
 [node name="GridArea" type="Area2D" parent="."]
+input_pickable = false
 
 [node name="Shape" type="CollisionPolygon2D" parent="GridArea"]
+
+[node name="InteractionShape" type="CollisionPolygon2D" parent="."]

--- a/TSCN/Game/Game.tscn
+++ b/TSCN/Game/Game.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://drliam15ta6fq" path="res://TSCN/Game/Controller.tscn" id="4_ak1ec"]
 
 [node name="Game" type="Node2D"]
+y_sort_enabled = true
 
 [node name="LevelManager" type="Node2D" parent="."]
 script = ExtResource("1_rxf7b")

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_6mp6r"]
+[sub_resource type="Resource" id="Resource_51av1"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -31,8 +31,10 @@ Hp = 10000
 NeedsRegion = true
 RegionRect = Rect2(179, 163, 287, 215)
 MaxProgress = 0
+IsPreSpawned = true
 
 [node name="Level" type="Node2D"]
+y_sort_enabled = true
 
 [node name="Navigation" type="NavigationRegion2D" parent="."]
 navigation_polygon = SubResource("NavigationPolygon_a5dn3")
@@ -51,7 +53,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_6mp6r")
+Data = SubResource("Resource_51av1")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)


### PR DESCRIPTION
Precisei refatorar como estamos selecionando as unidades/construções.

Esta PR:
- Modifica a forma de selecionar unidades
- Separa a seleção de construções e de unidades
- Separa a seleção de alvo unico ou de alvo multiplo (dentro da separação de construção e unidades)
- Modifica a forma de obter a area2D de construções mais a frente, incluindo metadados para atribuir apenas aos Buildings e não seus respectivos GridAreas (que sempre serão Y position maior)
- Centraliza os seletores (selecionar 1 aliado, multiplos, 1 construção, multiplas e funções auxiliares) numa classe "seletora"
- Centraliza as modulações (trocar de cor) quando dá hover (botar o mouse em cima) em uma construção para evitar repetição do código.