### PR TITLE
36 - [BUG] Validação de construção

### DIFF
--- a/Scripts/Systems/GameModes/BuildMode.cs
+++ b/Scripts/Systems/GameModes/BuildMode.cs
@@ -100,20 +100,18 @@ public partial class BuildMode : GameMode {
     private void ValidatePosition() {
         Area2D gridArea = CurrentBuilding.GetNode<Area2D>("GridArea");
         Array<Area2D> overlappingAreas = gridArea.GetOverlappingAreas();
+        IsOverlappingBuildings = false;
         foreach (var area in overlappingAreas) {
             if (area.Name == "GridArea") {
                 IsOverlappingBuildings = true;
                 break;
             }
         }
-        if(overlappingAreas.Count == 0) {
-            IsOverlappingBuildings = false;    
-        }
-        if (IsOverlappingBuildings) {
-            Building.ModulateBuilding(CurrentBuilding, BuildingInteractionStates.BUILDING_ERROR);
-        } else {
-            Building.ModulateBuilding(CurrentBuilding, BuildingInteractionStates.BUILDING_OK);
-        }
+
+        Building.ModulateBuilding(
+            CurrentBuilding,
+            IsOverlappingBuildings ? BuildingInteractionStates.BUILDING_ERROR : BuildingInteractionStates.BUILDING_OK
+        );
     }
 
     private void MovePreview() {

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_ddx6q"]
+[sub_resource type="Resource" id="Resource_lbhj3"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -53,7 +53,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_ddx6q")
+Data = SubResource("Resource_lbhj3")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)

--- a/project.godot
+++ b/project.godot
@@ -13,7 +13,6 @@ config_version=5
 config/name="Clawtopia Cs 4.3"
 run/main_scene="res://TSCN/Game/Game.tscn"
 config/features=PackedStringArray("4.3", "C#", "Forward Plus")
-boot_splash/bg_color=Color(0.964118, 0.857804, 0.85617, 1)
 config/icon="res://Assets/Characters/Allies/test_kitten_artstyle64.png"
 
 [display]


### PR DESCRIPTION
# Problema:

### Função ValidatePosition() em BuildMode
```cs
Area2D gridArea = CurrentBuilding.GetNode<Area2D>("GridArea");
        Array<Area2D> overlappingAreas = gridArea.GetOverlappingAreas();
        foreach (var area in overlappingAreas) {
            if (area.Name == "GridArea") {
                IsOverlappingBuildings = true;
                break;
            }
        }
        if(overlappingAreas.Count == 0) {
            IsOverlappingBuildings = false;    
        }
        if (IsOverlappingBuildings) {
            Building.ModulateBuilding(CurrentBuilding, BuildingInteractionStates.BUILDING_ERROR);
        } else {
            Building.ModulateBuilding(CurrentBuilding, BuildingInteractionStates.BUILDING_OK);
        }
```

O único condicional para reverter o `IsOverlappingBuildings` para false era `if(overlappingAreas.Count == 0)` e isso nunca iria acontecer pois sempre tem areas em sobreposição já que a propria construção soprepõe Area2D consigo mesma para diferentes funções.

# Solução:

```cs
Area2D gridArea = CurrentBuilding.GetNode<Area2D>("GridArea");
        Array<Area2D> overlappingAreas = gridArea.GetOverlappingAreas();
        IsOverlappingBuildings = false;
        foreach (var area in overlappingAreas) {
            if (area.Name == "GridArea") {
                IsOverlappingBuildings = true;
                break;
            }
        }

        Building.ModulateBuilding(
            CurrentBuilding,
            IsOverlappingBuildings ? BuildingInteractionStates.BUILDING_ERROR : BuildingInteractionStates.BUILDING_OK
        );
```
A variavel sempre é revertida para false antes da verificação e, então, caso o critério seja positivo, volta para true.
O boolean