### PR TITLE
36 - [BUG] Gato anda ao cancelar construção

### DIFF
--- a/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
@@ -2,22 +2,30 @@ using Godot;
 
 public partial class Build : EconomicState
 {
-	public override void Enter(){
-		Ally.ConstructionToBuild.CurrentBuilders.Add(Ally);
-		/*TODO
-		 TOCAR ANIMAÇÃO DE BUILD QUANDO TIVER*/
-	}
-	public override void Update(double delta){}
-	public override void Exit(){
-		Ally.ConstructionToBuild.CurrentBuilders.Remove(Ally);
-		Ally.AllyIsBuilding = false;
-	}
+    public override void Enter()
+    {
+        Ally.ConstructionToBuild.CurrentBuilders.Add(Ally);
+        /*TODO
+         TOCAR ANIMAÇÃO DE BUILD QUANDO TIVER*/
+    }
 
-	public override void MouseRightClicked(Vector2 coords){
-		if (!Ally.CurrentlySelected){ return; }
-		ChooseNextTargetPosition(coords);
-		ChangeState("Move");
-	}
-	public override void NavigationFinished(){}
-	
+    public override void Update(double delta) { }
+
+    public override void Exit()
+    {
+        Ally.ConstructionToBuild.CurrentBuilders.Remove(Ally);
+        Ally.AllyIsBuilding = false;
+    }
+
+    public override void MouseRightClicked(Vector2 coords)
+    {
+        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+            return;
+        }
+
+        ChooseNextTargetPosition(coords);
+        ChangeState("Move");
+    }
+
+    public override void NavigationFinished() { }
 }

--- a/Scripts/Entities/Characters/Allies/Economic/States/Collect.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Collect.cs
@@ -1,57 +1,70 @@
-	using Godot;
+using Godot;
 
 public partial class Collect : EconomicState
 {
-	// TIMER PARA TICK DE RECURSO COLETADO
-	public SceneTreeTimer ResourceTickTimer;
-	// IDENTIFICADOR DO RECURSO SENDO COLETADO ATUALMENTE
-	public string CurrentlyCollecting;
-	// CAPACIDADE MAXIMA DE RECURSO DA UNIDADE
-	[Export] public int MaxQuantity = 15;
-	// QUANTIDADE ATUAL
-	
-	// CONSTANTE DE QUANTOS AUMENTA POR TICK
-	[Export] public int QuantityPerTick = 3;
-	// TEMPO EM SEGUNDOS POR TICK
-	[Export] public float TickTime = 1.0f;
-	public override void Enter(){
-		// SEMPRE QUE ENTRAR NO ESTADO COLLECTING, MODIFICAR A VARIAVEL ACIMA
-		CurrentlyCollecting = Ally.InteractedResource;
-		//INICIAR O TIMER
-		ResourceTickTimer = GetTree().CreateTimer(TickTime); // tempo em segundos
-		ResourceTickTimer.Timeout += CollectTimeTicked; // CONECTANDO SIGNAL QUANDO O TEMPO ACABA 
-		GD.Print("I'm collecting: ", CurrentlyCollecting);
-	}
+    // IDENTIFICADOR DO RECURSO SENDO COLETADO ATUALMENTE
+    public string CurrentlyCollecting;
 
-	public override void Update(double delta) {
-	}
+    // CAPACIDADE MAXIMA DE RECURSO DA UNIDADE
+    [Export] public int MaxQuantity = 15;
+    // QUANTIDADE ATUAL
 
-	public override void Exit(){
-		ResourceTickTimer.Timeout -= CollectTimeTicked;
-		CurrentlyCollecting = null; // NA SAIDA DO ESTADO, MODIFICAR PARA NULL
-	}
+    // CONSTANTE DE QUANTOS AUMENTA POR TICK
+    [Export] public int QuantityPerTick = 3;
 
-	public void CollectTimeTicked(){
-		// VERIFICO SE A QUANTIDADE SOMADA NAO IRIA ULTRAPASSAR A QUANTIDADE MAXIMA
-		if (Ally.ResourceCurrentQuantity + QuantityPerTick < MaxQuantity){
-			Ally.ResourceCurrentQuantity += QuantityPerTick;
-		}else{
-			Ally.ResourceCurrentQuantity = MaxQuantity;
-		}
-		if (Ally.ResourceCurrentQuantity != MaxQuantity){
-			ResourceTickTimer = GetTree().CreateTimer(TickTime);
-			ResourceTickTimer.Timeout += CollectTimeTicked;
-		}else{
-			var target = GetClosestResourceBuilding(Ally.GlobalPosition, CurrentlyCollecting);
-			Ally.Navigation.SetTargetPosition(target);
-			Ally.Delivering = true;
-			ChangeState("Move");
-		}
-	}
+    // TIMER PARA TICK DE RECURSO COLETADO
+    public SceneTreeTimer ResourceTickTimer;
 
-	public override void MouseRightClicked(Vector2 coords){
-		if (!Ally.CurrentlySelected){ return; }
-		ChooseNextTargetPosition(coords);
-		ChangeState("Move");
-	}
+    // TEMPO EM SEGUNDOS POR TICK
+    [Export] public float TickTime = 1.0f;
+
+    public override void Enter()
+    {
+        // SEMPRE QUE ENTRAR NO ESTADO COLLECTING, MODIFICAR A VARIAVEL ACIMA
+        CurrentlyCollecting = Ally.InteractedResource;
+        //INICIAR O TIMER
+        ResourceTickTimer = GetTree().CreateTimer(TickTime); // tempo em segundos
+        ResourceTickTimer.Timeout += CollectTimeTicked; // CONECTANDO SIGNAL QUANDO O TEMPO ACABA 
+        GD.Print("I'm collecting: ", CurrentlyCollecting);
+    }
+
+    public override void Update(double delta) { }
+
+    public override void Exit()
+    {
+        ResourceTickTimer.Timeout -= CollectTimeTicked;
+        CurrentlyCollecting = null; // NA SAIDA DO ESTADO, MODIFICAR PARA NULL
+    }
+
+    public void CollectTimeTicked()
+    {
+        // VERIFICO SE A QUANTIDADE SOMADA NAO IRIA ULTRAPASSAR A QUANTIDADE MAXIMA
+        if (Ally.ResourceCurrentQuantity + QuantityPerTick < MaxQuantity) {
+            Ally.ResourceCurrentQuantity += QuantityPerTick;
+        }
+        else {
+            Ally.ResourceCurrentQuantity = MaxQuantity;
+        }
+
+        if (Ally.ResourceCurrentQuantity != MaxQuantity) {
+            ResourceTickTimer = GetTree().CreateTimer(TickTime);
+            ResourceTickTimer.Timeout += CollectTimeTicked;
+        }
+        else {
+            var target = GetClosestResourceBuilding(Ally.GlobalPosition, CurrentlyCollecting);
+            Ally.Navigation.SetTargetPosition(target);
+            Ally.Delivering = true;
+            ChangeState("Move");
+        }
+    }
+
+    public override void MouseRightClicked(Vector2 coords)
+    {
+        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+            return;
+        }
+
+        ChooseNextTargetPosition(coords);
+        ChangeState("Move");
+    }
 }

--- a/Scripts/Entities/Characters/Allies/Economic/States/Idle.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Idle.cs
@@ -2,23 +2,28 @@ using Godot;
 
 public partial class Idle : EconomicState
 {
-    public override void Enter(){
+    public override void Enter()
+    {
         Ally.Velocity = Vector2.Zero;
         /* TODO
          Tocar animacao de idle quando houver
         */
     }
 
-    public override void Update(double delta){
+    public override void Update(double delta)
+    {
         /*Nao faz nada, afinal e estado Idle*/
         //GD.Print("I'm idle"); // <- Apenas para DEBUG, sera removido depois
     }
 
-    public override void Exit(){
-    }
+    public override void Exit() { }
 
-    public override void MouseRightClicked(Vector2 coords){
-        if(!Ally.CurrentlySelected){ return; }
+    public override void MouseRightClicked(Vector2 coords)
+    {
+        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+            return;
+        }
+
         ChooseNextTargetPosition(coords);
         ChangeState("Move");
     }

--- a/Scripts/Entities/Characters/Allies/Economic/States/Move.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Move.cs
@@ -2,33 +2,39 @@ using Godot;
 
 public partial class Move : EconomicState
 {
-    public override void Enter(){
-    }
+    public override void Enter() { }
 
-    public override void Update(double delta){
+    public override void Update(double delta)
+    {
         Move();
     }
 
-    public override void Exit(){
-    }
+    public override void Exit() { }
 
-    public override void MouseRightClicked(Vector2 coords){
-        if (!Ally.CurrentlySelected){ return; }
+    public override void MouseRightClicked(Vector2 coords)
+    {
+        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+            return;
+        }
+
         ChooseNextTargetPosition(coords);
     }
 
-    public override void NavigationFinished(){
-        if (Ally.AllyIsBuilding){
+    public override void NavigationFinished()
+    {
+        if (Ally.AllyIsBuilding) {
             ChangeState("Building");
             return;
         }
-        if (Ally.InteractedWithBuilding){
-            if (!Ally.InteractedBuilding.IsBuilt){
+
+        if (Ally.InteractedWithBuilding) {
+            if (!Ally.InteractedBuilding.IsBuilt) {
                 Ally.ConstructionToBuild = Ally.InteractedBuilding;
                 ChangeState("Building");
                 return;
             }
-            switch (Ally.InteractedBuilding.Data.Type){
+
+            switch (Ally.InteractedBuilding.Data.Type) {
                 case Constants.TOWER:
                     ChangeState("Taking_shelter");
                     return;
@@ -37,13 +43,15 @@ public partial class Move : EconomicState
                     return;
             }
         }
-        if (Ally.InteractedResource != null && !Ally.Delivering){
+
+        if (Ally.InteractedResource != null && !Ally.Delivering) {
             ChangeState("Collecting");
             return;
         }
-        if (Ally.Delivering){
+
+        if (Ally.Delivering) {
             Ally.Navigation.SetTargetPosition(Ally.CurrentResourceLastPosition);
-            switch (Ally.InteractedResource){
+            switch (Ally.InteractedResource) {
                 case Constants.CATNIP:
                     Ally.LevelManager.EmitSignal("ResourceDelivered", Constants.CATNIP, Ally.ResourceCurrentQuantity);
                     break;
@@ -54,15 +62,18 @@ public partial class Move : EconomicState
                     Ally.LevelManager.EmitSignal("ResourceDelivered", Constants.SAND, Ally.ResourceCurrentQuantity);
                     break;
             }
+
             Ally.ResourceCurrentQuantity = 0;
             Ally.Delivering = false;
             return;
         }
+
         ChangeState("Idle");
     }
 
-    public void SeekResource(string resourceType){
-        switch (resourceType){
+    public void SeekResource(string resourceType)
+    {
+        switch (resourceType) {
             case Constants.CATNIP:
                 /*TODO implementar*/
                 break;

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_lbhj3"]
+[sub_resource type="Resource" id="Resource_psq82"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -53,7 +53,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_lbhj3")
+Data = SubResource("Resource_psq82")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)


### PR DESCRIPTION
# Problema:

```cs
public override void MouseRightClicked(Vector2 coords){
        if(!Ally.CurrentlySelected){ return; }
        ChooseNextTargetPosition(coords);
        ChangeState("Move");
    }
```

É um problema fundamental pela forma como signals funcionam. Uma vez conectados, eles SEMPRE respondem, independente do contexto. Quem precisa dar os contextos corretos é quem está fazendo o código, ou então ter um sistema para conectar e desconectar sinais conforme os contextos mudarem. Eu preferi fazer apenas uma abordagem mais simples de checagem de `GameMode`.

# Solução:

```cs
public override void MouseRightClicked(Vector2 coords)
    {
        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
            return;
        }

        ChooseNextTargetPosition(coords);
        ChangeState("Move");
    }
```

Foi feito em todos os estados do aliado e precisará ser feito nos próximos que existirem.