### PR TITLE
43 - [BUG] Correção na seleção multipla 

### DIFF
--- a/Scripts/Camera.cs
+++ b/Scripts/Camera.cs
@@ -1,35 +1,37 @@
 using Godot;
 
-
 public partial class Camera : Camera2D
 {
-    [ExportCategory("Camera Properties")]
-    [Export] public float Speed = 0.5f;
-    [Export] public float Sensitivity = 5.0f;
-    [Export] public float dragSensitivity = 1.0f;
-    [Export] public float ZoomAmmount = 0.3f;
-    [Export] public float MaxZoom = 2.0f;
-    [Export] public float MinZoom = 0.5f;
-
-    public Rect2 visibleRect;
-    public Vector2 mousePosition;
-    public Vector2 initialMousePosition;
-    public enum CameraMode 
+    public enum CameraMode
     {
-        Dragging, 
+        Dragging,
         Sliding
     }
+
+    private float bottomThreshold;
     public CameraMode CameraState = CameraMode.Sliding;
+    [Export] public float dragSensitivity = 1.0f;
+    public Vector2 initialMousePosition;
 
     private float leftThreshold;
+    [Export] public float MaxZoom = 2.0f;
+    [Export] public float MinZoom = 0.5f;
+    public Vector2 mousePosition;
     private float rightThreshold;
+    [Export] public float Sensitivity = 5.0f;
+
+    [ExportCategory("Camera Properties")] [Export]
+    public float Speed = 0.5f;
+
     private float topThreshold;
-    private float bottomThreshold;
+
+    public Rect2 visibleRect;
+    [Export] public float ZoomAmmount = 0.3f;
 
     public override void _Ready()
     {
         visibleRect = GetViewport().GetVisibleRect();
-        
+
         leftThreshold = visibleRect.Position.X;
         rightThreshold = visibleRect.Size.X;
         topThreshold = visibleRect.Position.Y;
@@ -40,9 +42,12 @@ public partial class Camera : Camera2D
     {
         mousePosition = GetViewport().GetMousePosition();
         //GD.Print(mousePosition);
-
         Vector2 direction = new Vector2(0, 0);
-        if(CameraState == CameraMode.Sliding){
+        if (CameraState == CameraMode.Sliding) {
+            if (OS.IsDebugBuild()) {
+                return;
+            }
+
             if (mousePosition.X < leftThreshold + Sensitivity && mousePosition.Y < topThreshold + Sensitivity)
                 direction = new Vector2(-1, -1).Normalized();
             else if (mousePosition.X > rightThreshold - Sensitivity && mousePosition.Y < topThreshold + Sensitivity)
@@ -59,45 +64,38 @@ public partial class Camera : Camera2D
                 direction = new Vector2(0, -1);
             else if (mousePosition.Y > bottomThreshold - Sensitivity || Input.IsActionPressed("camera_down"))
                 direction = new Vector2(0, +1);
-        
+
             Position += direction * Speed / Zoom.X;
         }
-        
 
-        if(CameraState == CameraMode.Dragging){
+
+        if (CameraState == CameraMode.Dragging) {
             Vector2 deltaMousePosition = mousePosition - initialMousePosition;
-            Position -= deltaMousePosition * dragSensitivity/Zoom.X;
+            Position -= deltaMousePosition * dragSensitivity / Zoom.X;
             initialMousePosition = mousePosition;
         }
-
     }
 
     public override void _Input(InputEvent @event)
     {
-        
-        if (Input.IsActionPressed("scroll_up"))
-        {
+        if (Input.IsActionPressed("scroll_up")) {
             Zoom += new Vector2(ZoomAmmount, ZoomAmmount);
         }
 
-        else if  (Input.IsActionPressed("scroll_down"))
-        {
+        else if (Input.IsActionPressed("scroll_down")) {
             Zoom -= new Vector2(ZoomAmmount, ZoomAmmount);
         }
+
         Zoom = new Vector2(Mathf.Clamp(Zoom.X, MinZoom, MaxZoom), Mathf.Clamp(Zoom.Y, MinZoom, MaxZoom));
 
-        if (@event is InputEventMouseButton mouseButtonEvent)
-        {
-            if(mouseButtonEvent.ButtonIndex == MouseButton.Middle && mouseButtonEvent.Pressed)
-            {
+        if (@event is InputEventMouseButton mouseButtonEvent) {
+            if (mouseButtonEvent.ButtonIndex == MouseButton.Middle && mouseButtonEvent.Pressed) {
                 CameraState = CameraMode.Dragging;
                 initialMousePosition = mousePosition;
             }
-            else if(mouseButtonEvent.ButtonIndex == MouseButton.Middle && !mouseButtonEvent.Pressed)
-            {
+            else if (mouseButtonEvent.ButtonIndex == MouseButton.Middle && !mouseButtonEvent.Pressed) {
                 CameraState = CameraMode.Sliding;
             }
         }
-             
     }
-} 
+}

--- a/Scripts/Systems/Selectors.cs
+++ b/Scripts/Systems/Selectors.cs
@@ -1,4 +1,3 @@
-using ClawtopiaCs.Scripts.Entities.Building;
 using Godot;
 using Godot.Collections;
 
@@ -9,30 +8,26 @@ public partial class Selectors : Node2D
     private static Building SelectTopBuilding(Array<Area2D> overlappingAreas)
     {
         var buildingInFront = new Building();
-        if (overlappingAreas.Count == 1)
-        {
+        if (overlappingAreas.Count == 1) {
             var isBuilding = overlappingAreas[0].HasMeta(new StringName(BuildingData.PROP_ISBUILDING));
-            
-            if (isBuilding)
-            {
-                buildingInFront = (Building)overlappingAreas[0];   
-            } 
+
+            if (isBuilding) {
+                buildingInFront = (Building)overlappingAreas[0];
+            }
         }
-        else
-        {
+        else {
             foreach (var area in overlappingAreas) {
                 var isBuilding = area.GetParent().HasMeta(new StringName(BuildingData.PROP_ISBUILDING));
                 var hasHigherY = area.GlobalPosition.Y > buildingInFront.GlobalPosition.Y;
-                if (hasHigherY && isBuilding)
-                {
+                if (hasHigherY && isBuilding) {
                     buildingInFront = (Building)area.GetParent();
                 }
-            }   
+            }
         }
 
         return buildingInFront;
     }
- 
+
     public static void SelectSingleBuilding(Array<Area2D> overlappingAreas, UI ui)
     {
         var buildingInFront = SelectTopBuilding(overlappingAreas);
@@ -50,7 +45,7 @@ public partial class Selectors : Node2D
     public static Ally SelectSingleUnit(Array<Area2D> overlappingAreas, UI ui)
     {
         var ally = SelectTopUnit(overlappingAreas);
-        
+
         if (ally is null) {
             return null;
         }
@@ -62,9 +57,13 @@ public partial class Selectors : Node2D
         return ally;
     }
 
-    public static Array<Ally> SelectMultipleUnits(Array<Area2D> overlappingAreas, UI ui)
+    public static Array<Ally> SelectMultipleUnits(Array<Area2D> overlappingAreas, Array<Ally> selection = null)
     {
-        var selectedAllies = new Array<Ally>();
+        Array<Ally> selectedAllies = new();
+        if (selection != null) {
+            selectedAllies = selection;
+        }
+
         foreach (var area in overlappingAreas) {
             if (area.GetParent() is not Ally ally) continue;
             selectedAllies.Add(ally);
@@ -72,7 +71,7 @@ public partial class Selectors : Node2D
             var selectionCircle = ally.GetNode<Line2D>("SelectionCircle");
             selectionCircle.Visible = true;
         }
-        
+
         return selectedAllies;
     }
 

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_psq82"]
+[sub_resource type="Resource" id="Resource_vcme1"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -53,7 +53,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_psq82")
+Data = SubResource("Resource_vcme1")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)

--- a/TSCN/Systems/GameModes/SimulationMode.tscn
+++ b/TSCN/Systems/GameModes/SimulationMode.tscn
@@ -2,5 +2,10 @@
 
 [ext_resource type="Script" path="res://Scripts/Systems/GameModes/SimulationMode.cs" id="1_qov7i"]
 
-[node name="SimulationMode" type="Node2D"]
+[node name="SimulationMode" type="Node2D" node_paths=PackedStringArray("Debug")]
 script = ExtResource("1_qov7i")
+Debug = NodePath("DEBUG")
+
+[node name="DEBUG" type="Label" parent="."]
+offset_right = 264.0
+offset_bottom = 105.0


### PR DESCRIPTION
# Problema:

Temos a feature de pressionar **ctrl** durante a seleção, seja em clique ou em caixa, para apenas adicionar a seleção na seleção que já existe, em vez de eliminar a seleção atual e selecionar a nova.

O problema consistia no fato de não estar fazendo isso apropriadamente quando se tratava da seleção em caixa, não estava levando em consideração a seleção anterior que foi feita. 

```cs
if (SelectedAllies.Count > 0 && !Input.IsActionPressed("Multiple")) {
    Selectors.ClearSelectedAllies(SelectedAllies);
    SelectedAllies = Selectors.SelectMultipleUnits(overlappingAreas);
    }
    else {
        SelectedAllies = Selectors.SelectMultipleUnits(overlappingAreas, SelectedAllies);
    }
```

Um simples caso de = (atribuição de variavel) que omitia toda a seleção anterior. Ao mesmo tempo, também não passava pelo ClearSelectedAllies, pois estava com a ação de seleção multipla pressionada.

# Solução:

Modifiquei a função SelectMultipleUnits para que possamos definir nos parâmetros se deve apenas selecionar a nova ou juntar a atual com a nova.

```cs
public static Array<Ally> SelectMultipleUnits(Array<Area2D> overlappingAreas, Array<Ally> selection = null)
    {
        Array<Ally> selectedAllies = new();
        if (selection != null) {
            selectedAllies = selection;
        }

        foreach (var area in overlappingAreas) {
            if (area.GetParent() is not Ally ally) continue;
            selectedAllies.Add(ally);
            ally.CurrentlySelected = true;
            var selectionCircle = ally.GetNode<Line2D>("SelectionCircle");
            selectionCircle.Visible = true;
        }

        return selectedAllies;
    }
```