### PR TITLE
45 - Refatorar Mode Manager

### DIFF
--- a/Scripts/Systems/Controller/Controller.cs
+++ b/Scripts/Systems/Controller/Controller.cs
@@ -2,33 +2,42 @@ using Godot;
 
 public partial class Controller : Node
 {
-	[Signal]
-	public delegate void MouseDoubleClickedEventHandler();
-	[Signal]
-	public delegate void MousePressedEventHandler(Vector2 coords);
-	[Signal]
-	public delegate void MouseReleasedEventHandler(Vector2 coords);
-	[Signal]
-	public delegate void MouseRightPressedEventHandler(Vector2 coords);
+    [Signal]
+    public delegate void MouseDoubleClickedEventHandler();
 
-	public ModeManager ModeManager;
-	public override void _Ready(){
-		ModeManager = GetNode<ModeManager>("/root/Game/ModeManager");
-	}
+    [Signal]
+    public delegate void MousePressedEventHandler(Vector2 coords);
 
-	public override void _Input(InputEvent @event){
-		var eventButton = @event as InputEventMouseButton;
-		if (eventButton is { Pressed: true, ButtonIndex: MouseButton.Left }){
-			EmitSignal("MousePressed", ModeManager.CurrentLevel.GetLocalMousePosition());
-		}
-		if (eventButton is { Pressed: false, ButtonIndex: MouseButton.Left }){
-			EmitSignal("MouseReleased", ModeManager.CurrentLevel.GetLocalMousePosition());
-		}
-		if (eventButton is { DoubleClick: true, ButtonIndex: MouseButton.Left }){
-			EmitSignal("MouseDoubleClicked", ModeManager.CurrentLevel.GetLocalMousePosition());
-		}
-		if (eventButton is { Pressed: true, ButtonIndex: MouseButton.Right }){
-			EmitSignal("MouseRightPressed", ModeManager.CurrentLevel.GetLocalMousePosition());
-		}
-	}
+    [Signal]
+    public delegate void MouseReleasedEventHandler(Vector2 coords);
+
+    [Signal]
+    public delegate void MouseRightPressedEventHandler(Vector2 coords);
+
+    public ModeManager ModeManager;
+
+    public override void _Ready()
+    {
+        ModeManager = GetNode<ModeManager>("/root/Game/ModeManager");
+    }
+
+    public override void _Input(InputEvent @event)
+    {
+        var eventButton = @event as InputEventMouseButton;
+        if (eventButton is { Pressed: true, ButtonIndex: MouseButton.Left }) {
+            EmitSignal(SignalName.MousePressed, ModeManager.CurrentLevel.GetLocalMousePosition());
+        }
+
+        if (eventButton is { Pressed: false, ButtonIndex: MouseButton.Left }) {
+            EmitSignal(SignalName.MouseReleased, ModeManager.CurrentLevel.GetLocalMousePosition());
+        }
+
+        if (eventButton is { DoubleClick: true, ButtonIndex: MouseButton.Left }) {
+            EmitSignal(SignalName.MouseDoubleClicked, ModeManager.CurrentLevel.GetLocalMousePosition());
+        }
+
+        if (eventButton is { Pressed: true, ButtonIndex: MouseButton.Right }) {
+            EmitSignal(SignalName.MouseRightPressed, ModeManager.CurrentLevel.GetLocalMousePosition());
+        }
+    }
 }

--- a/Scripts/Systems/GameModes/BuildMode.cs
+++ b/Scripts/Systems/GameModes/BuildMode.cs
@@ -1,25 +1,27 @@
-using Godot;
 using System;
 using ClawtopiaCs.Scripts.Entities.Building;
 using ClawtopiaCs.Scripts.Systems.GameModes;
+using Godot;
 using Godot.Collections;
 
-public partial class BuildMode : GameMode {
+public partial class BuildMode : GameMode
+{
+    public string BuildingType;
+
+    public Building CurrentBuilding;
+
+    public Array<Ally> CurrentConstructors;
+    public bool IsOverlappingBuildings = false;
+
+    public Vector2 MousePosition;
 
     public int TileSizeX = 64;
     public int TileSizeY = 32;
 
-    public Vector2 MousePosition;
-
-    public string BuildingType;
-
-    public Building CurrentBuilding;
-    public bool IsOverlappingBuildings = false;
-
-    public Array<Ally> CurrentConstructors;
-    public override void Enter() {
+    public override void Enter()
+    {
         String buildingPath = Constants.BUILDING_PATH;
-        if(BuildingType == Constants.TOWER) {
+        if (BuildingType == Constants.TOWER) {
             ModeManager.FightersTowerCount++;
             ModeManager.BuildingCount++;
             InstantiateBuilding(buildingPath);
@@ -27,15 +29,17 @@ public partial class BuildMode : GameMode {
             CurrentBuilding.Name = ModeManager.TowerType + "_T1_" + CurrentBuilding.SelfIndex;
             CurrentBuilding.Data = GD.Load<BuildingData>("res://Resources/Buildings/Towers/Fighters/Fighters.tres");
         }
-        if(BuildingType == Constants.COMMUNE){
-           ModeManager.GreatCommuneCount++;
-           ModeManager.BuildingCount++;
-           InstantiateBuilding(buildingPath);
-           CurrentBuilding.SelfIndex = ModeManager.GreatCommuneCount;
-           CurrentBuilding.Name = Constants.COMMUNE;   
-           CurrentBuilding.Data = GD.Load<BuildingData>("res://Resources/Buildings/GreatCommune/GreatCommune.tres");
-        }    
-        if(BuildingType == Constants.RESOURCE){
+
+        if (BuildingType == Constants.COMMUNE) {
+            ModeManager.GreatCommuneCount++;
+            ModeManager.BuildingCount++;
+            InstantiateBuilding(buildingPath);
+            CurrentBuilding.SelfIndex = ModeManager.GreatCommuneCount;
+            CurrentBuilding.Name = Constants.COMMUNE;
+            CurrentBuilding.Data = GD.Load<BuildingData>("res://Resources/Buildings/GreatCommune/GreatCommune.tres");
+        }
+
+        if (BuildingType == Constants.RESOURCE) {
             ModeManager.SalmonCottageCount++;
             ModeManager.BuildingCount++;
             InstantiateBuilding(buildingPath);
@@ -43,7 +47,8 @@ public partial class BuildMode : GameMode {
             CurrentBuilding.Name = "" + ModeManager.ResourceBuildType + "_" + CurrentBuilding.SelfIndex;
             CurrentBuilding.Data = GD.Load<BuildingData>("res://Resources/Buildings/Economy/Salmon/SalmonCottage.tres");
         }
-        if (BuildingType == Constants.HOUSE){
+
+        if (BuildingType == Constants.HOUSE) {
             ModeManager.HouseCount++;
             ModeManager.BuildingCount++;
             InstantiateBuilding(buildingPath);
@@ -51,6 +56,7 @@ public partial class BuildMode : GameMode {
             CurrentBuilding.Name = "" + ModeManager.ResourceBuildType + "_" + CurrentBuilding.SelfIndex;
             CurrentBuilding.Data = GD.Load<BuildingData>("res://Resources/Buildings/House/House.tres");
         }
+
         CurrentBuilding.InputPickable = false;
         ModeManager.CurrentLevel.AddChild(CurrentBuilding);
         MousePosition = ModeManager.CurrentLevel.GetGlobalMousePosition();
@@ -58,35 +64,32 @@ public partial class BuildMode : GameMode {
         CurrentConstructors = GetNode<SimulationMode>("../SimulationMode").SelectedAllies;
     }
 
-    public override void Update() {
+    public override void Update()
+    {
         MovePreview();
         ValidatePosition();
     }
-    
+
     public override void MouseReleased(Vector2 coords)
     {
-        if (ModeManager.CurrentMode is not BuildMode) {
-            return;
-        }
         ConfirmBuilding();
     }
 
     public override void MouseRightPressed(Vector2 coords)
     {
-        if (ModeManager.CurrentMode is not BuildMode) {
-            return;
-        }
         CancelBuilding();
     }
 
-    private void CancelBuilding() {
+    private void CancelBuilding()
+    {
         ModeManager.FightersTowerCount--;
         ModeManager.BuildingCount--;
         CurrentBuilding.QueueFree();
         EmitSignal("ModeTransition", "SimulationMode", "", "");
     }
 
-    private void ConfirmBuilding() {
+    private void ConfirmBuilding()
+    {
         if (!IsOverlappingBuildings) {
             CurrentBuilding.RebakeAddBuilding();
             CurrentBuilding.Rebake();
@@ -97,7 +100,8 @@ public partial class BuildMode : GameMode {
         }
     }
 
-    private void ValidatePosition() {
+    private void ValidatePosition()
+    {
         Area2D gridArea = CurrentBuilding.GetNode<Area2D>("GridArea");
         Array<Area2D> overlappingAreas = gridArea.GetOverlappingAreas();
         IsOverlappingBuildings = false;
@@ -114,7 +118,8 @@ public partial class BuildMode : GameMode {
         );
     }
 
-    private void MovePreview() {
+    private void MovePreview()
+    {
         MousePosition = ModeManager.CurrentLevel.GetGlobalMousePosition();
         float xDifference = MousePosition.X - CurrentBuilding.GlobalPosition.X;
         float yDifference = MousePosition.Y - CurrentBuilding.GlobalPosition.Y;
@@ -122,28 +127,32 @@ public partial class BuildMode : GameMode {
         float newY = 0;
         if (xDifference > (TileSizeX / 2)) {
             newX = (TileSizeX / 2);
-
-        } else if (xDifference < (TileSizeX / 2) * -1) {
+        }
+        else if (xDifference < (TileSizeX / 2) * -1) {
             newX = (TileSizeX / 2) * -1;
         }
+
         if (yDifference > (TileSizeY / 2)) {
             newY = (TileSizeY / 2);
-        } else if (yDifference < (TileSizeY / 2) * -1) {
+        }
+        else if (yDifference < (TileSizeY / 2) * -1) {
             newY = (TileSizeY / 2) * -1;
         }
+
         CurrentBuilding.GlobalPosition = new Vector2(
             CurrentBuilding.GlobalPosition.X + newX,
             CurrentBuilding.GlobalPosition.Y + newY
         );
-
     }
 
-    private void InstantiateBuilding(String buildingPath) {
+    private void InstantiateBuilding(String buildingPath)
+    {
         PackedScene buildingScene = GD.Load<PackedScene>(buildingPath);
         CurrentBuilding = (Building)buildingScene.Instantiate();
     }
 
-    public void WhenBuildingCompleted(Building building){
+    public void WhenBuildingCompleted(Building building)
+    {
         Building.ModulateBuilding(building, BuildingInteractionStates.BUILD_FINISHED);
         building.CurrentBuilders.Clear();
     }

--- a/Scripts/Systems/GameModes/GameMode.cs
+++ b/Scripts/Systems/GameModes/GameMode.cs
@@ -1,32 +1,34 @@
-using Godot;
 using System;
+using Godot;
 
-public partial class GameMode : Node2D {
+public partial class GameMode : Node2D
+{
+    [Signal]
+    public delegate void BuildCompletedEventHandler(Building building);
+
+    [Signal]
+    public delegate void ConstructionStartedEventHandler(Building building);
+
+    [Signal]
+    public delegate void ModeTransitionEventHandler(String mode, String building, String type);
 
     public enum Modes
     {
         BUILD_MODE = 0,
         SIMULATION_MODE,
     }
-    
-    [Signal]
-    public delegate void ModeTransitionEventHandler(String mode, String building, String type);
 
-    [Signal]
-    public delegate void ConstructionStartedEventHandler(Building building);
-    [Signal]
-    public delegate void BuildCompletedEventHandler(Building building);
-
-    public Director Director;
+    public Controller Controller;
     public Node2D CurrentLevel;
 
-    public ModeManager ModeManager;
-    
-    public Controller Controller;
+    public Director Director;
 
     public Rid MapRid;
 
-    public override void _Ready(){
+    public ModeManager ModeManager;
+
+    public override void _Ready()
+    {
         Initialize();
     }
 
@@ -36,18 +38,12 @@ public partial class GameMode : Node2D {
 
     public virtual void MousePressed(Vector2 coords) { }
     public virtual void MouseReleased(Vector2 coords) { }
-    
+
     public virtual void MouseRightPressed(Vector2 coords) { }
 
-    public void Initialize(){
+    public void Initialize()
+    {
         //Director = GetNode<Director>("/root/Game/Director");
         ModeManager = GetParent<ModeManager>();
-        Controller = GetNode<Controller>("/root/Game/Controller");
-        Controller.MousePressed += MousePressed;
-        Controller.MouseReleased += MouseReleased;
-        Controller.MouseRightPressed += MouseRightPressed;
     }
-
-    
 }
-

--- a/Scripts/Systems/GameModes/ModeManager.cs
+++ b/Scripts/Systems/GameModes/ModeManager.cs
@@ -1,44 +1,53 @@
+using System;
 using Godot;
 using Godot.Collections;
-using System;
 
 public partial class ModeManager : Node2D
 {
-    public bool CurrentlyBaking = false;
-    public Array<Building> BuildingsToBake = new();
-    public NavigationRegion2D Region;
-
-    public Dictionary GameModes = (Dictionary) new Dictionary<string, Variant>();
-    public GameMode CurrentMode;
     public int BuildingCount;
+    public Array<Building> BuildingsToBake = new();
 
-    public string TowerType;
-    
-    public int FightersTowerCount;
-    public int GreatCommuneCount;
-    public int SalmonCottageCount;
-
-    public String ResourceBuildType;
-    public int ResourceBuildCount;
-
-    public int HouseCount;
+    public Controller Controller;
+    public Node2D CurrentLevel;
+    public bool CurrentlyBaking = false;
+    public GameMode CurrentMode;
 
     public Director Director;
-    public Node2D CurrentLevel;
 
-    public override void _Ready() {
+    public int FightersTowerCount;
+
+    public Dictionary GameModes = (Dictionary)new Dictionary<string, Variant>();
+    public int GreatCommuneCount;
+
+    public int HouseCount;
+    public NavigationRegion2D Region;
+    public int ResourceBuildCount;
+
+    public String ResourceBuildType;
+    public int SalmonCottageCount;
+
+    public string TowerType;
+
+    public override void _Ready()
+    {
         Initialize();
     }
 
-    public void Initialize() {
+    public void Initialize()
+    {
         //Director = GetNode<Director>("/root/Game/Director");
         CurrentLevel = GetNode<Node2D>("/root/Game/LevelManager/Level");
+        Controller = GetNode<Controller>("/root/Game/Controller");
         SetGameModes();
         SetInitialBuildings();
-        CurrentMode = (GameMode) GameModes["SimulationMode"];
+        CurrentMode = (GameMode)GameModes["SimulationMode"];
+        Controller.MousePressed += MousePressed;
+        Controller.MouseReleased += MouseReleased;
+        Controller.MouseRightPressed += MouseRightPressed;
     }
 
-    public void ChangeMode(String mode, String building, String type) {
+    public void ChangeMode(String mode, String building, String type)
+    {
         CurrentMode.Exit();
         CurrentMode = (GameMode)GameModes[mode];
         if (CurrentMode is BuildMode buildMode) {
@@ -52,14 +61,33 @@ public partial class ModeManager : Node2D
                     break;
             }
         }
+
         CurrentMode.Enter();
     }
 
-    public override void _Process(double delta) {
+    public override void _Process(double delta)
+    {
         CurrentMode.Update();
     }
 
-    public void SetGameModes(){
+    public void MousePressed(Vector2 coords)
+    {
+        CurrentMode.MousePressed(coords);
+    }
+
+    public void MouseReleased(Vector2 coords)
+    {
+        CurrentMode.MouseReleased(coords);
+    }
+
+    public void MouseRightPressed(Vector2 coords)
+    {
+        CurrentMode.MouseRightPressed(coords);
+    }
+
+
+    public void SetGameModes()
+    {
         Array<Node> modes = GetChildren();
         foreach (var mode in modes) {
             if (mode is GameMode gameMode) {
@@ -69,35 +97,39 @@ public partial class ModeManager : Node2D
         }
     }
 
-    public void SetInitialBuildings(){
-        Array<Node> nodes = GetNode("/root/Game/LevelManager/Level").GetChildren();
+    public void SetInitialBuildings()
+    {
+        Array<Node> nodes = CurrentLevel.GetChildren();
         foreach (var node in nodes) {
-            if (node is Building build){
+            if (node is Building build) {
                 BuildingCount++;
                 Building building = build;
                 if (building.Data.Type == Constants.TOWER) {
-                    if (building.Name.ToString().Contains(Constants.FIGHTERS)){
+                    if (building.Name.ToString().Contains(Constants.FIGHTERS)) {
                         building.SelfIndex = FightersTowerCount;
                         FightersTowerCount++;
                     }
                 }
-                if (building.Data.Type == Constants.RESOURCE) { 
-                    if (building.Name.ToString().Contains(Constants.COMMUNIST)){
+
+                if (building.Data.Type == Constants.RESOURCE) {
+                    if (building.Name.ToString().Contains(Constants.COMMUNIST)) {
                         building.SelfIndex = SalmonCottageCount;
                         SalmonCottageCount++;
                     }
                 }
-                if (building.Data.Type == Constants.COMMUNE) { 
+
+                if (building.Data.Type == Constants.COMMUNE) {
                     building.SelfIndex = GreatCommuneCount;
                     GreatCommuneCount++;
                 }
+
                 BuildingsToBake.Add(building);
                 building.RebakeAddBuilding(true);
             }
         }
-        Region = GetNode<NavigationRegion2D>("/root/Game/LevelManager/Level/Navigation");
+
+        Region = CurrentLevel.GetNode<NavigationRegion2D>("Navigation");
         Region.BakeNavigationPolygon();
         BuildingsToBake.Clear();
     }
-
 }

--- a/Scripts/Systems/GameModes/SimulationMode.cs
+++ b/Scripts/Systems/GameModes/SimulationMode.cs
@@ -56,10 +56,6 @@ public partial class SimulationMode : GameMode
 
     public override void MousePressed(Vector2 coords)
     {
-        if (ModeManager.CurrentMode is not SimulationMode) {
-            return;
-        }
-
         StartingPoint = coords;
         SelectionArea = new Area2D();
         SelectionPolygon = new CollisionShape2D();
@@ -76,10 +72,6 @@ public partial class SimulationMode : GameMode
 
     public override void MouseReleased(Vector2 coords)
     {
-        if (ModeManager.CurrentMode is not SimulationMode) {
-            return;
-        }
-
         var hasBuildings = BuildingsToInteract.Count > 0;
         var treatAsClick = VisualSelection.SelectionShape.Size is { X: < 2, Y: < 2 };
         SelectEntities(treatAsClick, hasBuildings);

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -14,7 +14,7 @@ vertices = PackedVector2Array(313.641, 1016, 304.047, 1020.79, 278.711, 1007.82,
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3), PackedInt32Array(4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11), PackedInt32Array(12, 13, 14), PackedInt32Array(12, 14, 15)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(304, 1032, -696, 520, 688, -176, 1680, 344)])
 
-[sub_resource type="Resource" id="Resource_vcme1"]
+[sub_resource type="Resource" id="Resource_3sjx3"]
 resource_local_to_scene = true
 script = ExtResource("7_pws6j")
 Offset = Vector2(0, 0)
@@ -53,7 +53,7 @@ position = Vector2(576, 324)
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
 IsPreSpawned = true
-Data = SubResource("Resource_vcme1")
+Data = SubResource("Resource_3sjx3")
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]
 position = Vector2(688, 424)


### PR DESCRIPTION
# Problema:
- Descrito na issue: #45 

# Solução:
Implementei o conceito de State machine para usar nesse ModeManager, de fato, como deveria ser. Quem responde aos sinais do Controller agora é o ModeManager. O ModeManager agora chama o, por exemplo, MousePressed do CurrentMode, em vez do próprio BuildMode ou SimulationMode responderem ao Controller diretamente. Há essa camada extra de controle agora.

**Em ModeManager.cs:**
```cs
public void Initialize()
    {
        //Director = GetNode<Director>("/root/Game/Director");
        CurrentLevel = GetNode<Node2D>("/root/Game/LevelManager/Level");
        Controller = GetNode<Controller>("/root/Game/Controller");
        SetGameModes();
        SetInitialBuildings();
        CurrentMode = (GameMode)GameModes["SimulationMode"];
        Controller.MousePressed += MousePressed;
        Controller.MouseReleased += MouseReleased;
        Controller.MouseRightPressed += MouseRightPressed;
    }
```

Controller agora referenciado e sinais conectados diretamente ao ModeManager.

```cs
public void MousePressed(Vector2 coords)
    {
        CurrentMode.MousePressed(coords);
    }

    public void MouseReleased(Vector2 coords)
    {
        CurrentMode.MouseReleased(coords);
    }

    public void MouseRightPressed(Vector2 coords)
    {
        CurrentMode.MouseRightPressed(coords);
    }
```

ModeManager apenas chama o mesmo método de CurrentMode, sem se preocupar com qual mode é o atual.