### PR TITLE
feat: returns to purrlament when no resource building available

### DIFF
--- a/Scripts/Constants.cs
+++ b/Scripts/Constants.cs
@@ -39,6 +39,8 @@ public partial class Constants : Node
     public const string COMMUNE_EXTERNAL_NAME = "Purrlamento";
     public const string FIGHTERS_TOWER_EXTERNAL_NAME = "Torre de Lutadores";
     public const string FISHERMAN_HOUSE_EXTERNAL_NAME = "Cabana do Pescador";
+    public const string DISTILLERY_EXTERNAL_NAME = "Destilaria";
+    public const string SAND_MINE_EXTERNAL_NAME = "Mina de Areia";
 
     public const string BUILDING_PATH = "res://TSCN/Entities/Buildings/Building.tscn";
     public const string MODE_MANAGER_PATH = "/root/Game/ModeManager";

--- a/Scripts/Entities/Building/Building.cs
+++ b/Scripts/Entities/Building/Building.cs
@@ -83,6 +83,7 @@ public partial class Building : Area2D
         if (Data.Type.Equals(Constants.COMMUNE))
         {
             Name = Constants.COMMUNE_EXTERNAL_NAME;
+            LevelManager.Purrlament = this;
         }
 
         if (Data.Type == Constants.HOUSE)
@@ -109,10 +110,10 @@ public partial class Building : Area2D
                     Name = Constants.FISHERMAN_HOUSE_EXTERNAL_NAME;
                     break;
                 case Constants.CATNIP:
-                    /*TODO IMPLEMENTAR*/
+                    Name = Constants.DISTILLERY_EXTERNAL_NAME;
                     break;
                 case Constants.SAND:
-                    /*TODO IMPLEMENTAR*/
+                    Name = Constants.SAND_MINE_EXTERNAL_NAME;
                     break;
             }
         }

--- a/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
@@ -48,6 +48,17 @@ public partial class EconomicState : AllyState
     {
         Vector2 closestBuildingPosition = default;
 
+        if (Ally.LevelManager.CatnipBuildings.Count == 0 &&
+            Ally.LevelManager.SalmonBuildings.Count == 0 &&
+            Ally.LevelManager.SandBuildings.Count == 0)
+        {
+            closestBuildingPosition = RecalculateCoords(Ally.GlobalPosition,
+                Ally.LevelManager.Purrlament.GlobalPosition,
+                true);
+
+            return closestBuildingPosition;
+        }
+
         switch (resource)
         {
             case Constants.SALMON:

--- a/Scripts/Entities/Characters/State.cs
+++ b/Scripts/Entities/Characters/State.cs
@@ -1,91 +1,110 @@
-using Godot;
 using System;
 using ClawtopiaCs.Scripts.Systems.GameModes;
-
+using Godot;
 
 public partial class State : Node
 {
     [Signal]
     public delegate void StateTransitionEventHandler(State current, String next);
-    
+
+    public BuildMode BuildMode;
+    public Controller Controller;
+    public ModeManager ModeManager;
+    public SimulationMode SimulationMode;
+
     // Referências recorrentes
     public Unit Unit;
-    public SimulationMode SimulationMode;
-    public BuildMode BuildMode;
-    public ModeManager ModeManager;
-    public Controller Controller;
-    
-    // Funçôes recorrentes na maquina de estado
-    public virtual void Enter(){}
-    public virtual void Update(double delta){}
-    public virtual void Exit(){}
-    public virtual void MouseRightClicked(Vector2 coords){}
-    public virtual void NavigationFinished(){}
 
-    
+    // Funçôes recorrentes na maquina de estado
+    public virtual void Enter() {}
+
+    public virtual void Update(double delta) {}
+
+    public virtual void Exit() {}
+
+    public virtual void MouseRightClicked(Vector2 coords) {}
+
+    public virtual void NavigationFinished() {}
+
+
     /// <summary>
     /// Inicializacao basica para todos os estados de qualquer unidade.
     /// Cada estado chama esta funcao em sua própria <c>_Ready()</c> e após isso inicializa dados especificos
     /// daquela unidade e estado. <br></br><br></br>&#10;
     /// </summary>
-    public void InitializeUnit(){
+    public void InitializeUnit()
+    {
         Unit = GetParent().GetParent<Unit>();
         ModeManager = GetNode<ModeManager>("/root/Game/ModeManager");
         SimulationMode = ModeManager.GetNode<SimulationMode>("SimulationMode");
         Unit.Navigation.VelocityComputed += VelocityComputed;
     }
 
-    
+
     /// <summary>
     /// <param name="next">Para qual estado ir</param>
     /// Emite o sinal de <c>StateTransition</c> para trocar de um estado para o outro. 
     /// </summary>
-    public void ChangeState(string next){
+    public void ChangeState(string next)
+    {
         EmitSignal("StateTransition", this, next);
     }
-    
-    
+
+
     /// <summary>
     /// <param name="safeVelocity">Velocidade pós calculo de avoidance.</param>
     /// Recebe a velocidade, multiplica pela velocidade de movimento da unidade e modifica a velocidade do CharacterBody, após isso chamando <c>MoveAndSlide</c>
     /// </summary>
-    public void VelocityComputed(Vector2 safeVelocity) {
+    public void VelocityComputed(Vector2 safeVelocity)
+    {
         Unit.Velocity = safeVelocity * Unit.Attributes.MoveSpeed;
         Unit.MoveAndSlide();
     }
-    
-    
+
+
     /// <summary>
     /// Recalcula as coordenadas baseado na posicao do aliado e da construçao selecionada.
     /// Pressupoe-se que a este ponto o clique direito foi efetuado em cima de uma construcao.
     /// </summary>
     /// <param name="allyPosition">A posicao global do aliado.</param>
     /// <param name="buildingPosition">A posicao global da construcao.</param>
+    /// <param name="isPurrlament">Checa se é o purrlamento para fazer calculos adicionais</param>
     /// <returns> <c>Vector2</c> coordenadas globais.</returns>
-    public Vector2 RecalculateCoords(Vector2 allyPosition, Vector2 buildingPosition){
+    public Vector2 RecalculateCoords(Vector2 allyPosition, Vector2 buildingPosition, bool isPurrlament = false)
+    {
         var buildMode = ModeManager.GetNode<BuildMode>("BuildMode");
-        var x = buildingPosition.X - allyPosition.X > 0? -1 : 1;
-        var y = buildingPosition.Y - allyPosition.Y > 0? 1 : -1;
+        var x = buildingPosition.X - allyPosition.X > 0 ? -1 : 1;
+        var y = buildingPosition.Y - allyPosition.Y > 0 ? 1 : -1;
         var newCoords = new Vector2(
             buildingPosition.X + (buildMode.TileSizeX * x),
             buildingPosition.Y + (buildMode.TileSizeY * y)
         );
+
+        if (!isPurrlament) return newCoords;
+
+        newCoords.X += 100 * x;
+        newCoords.Y += 100 * y;
+
         return newCoords;
     }
-    
-    
+
+
     /// <summary>
     /// Pega a próxima posição de navegação, calcula a distância e modifica a velocidade do navigationAgent.<br></br><br></br>
     /// Caso avoidance esteja ligado, ele aguarda pelo signal <c>VelocityComputed</c> para receber a nova velocidade após o calculo de avoidance.<br></br><br></br>
     /// Caso esteja desligado, chama a função de mover o aliado com a velocidade desconsiderando avoidance.
     /// </summary>
-    public void Move(){
+    public void Move()
+    {
         var nextPathPos = Unit.Navigation.GetNextPathPosition();
         var newVelocity = Unit.GlobalPosition.DirectionTo(nextPathPos);
-        if (Unit.Navigation.AvoidanceEnabled){
+
+        if (Unit.Navigation.AvoidanceEnabled)
+        {
             Unit.Navigation.Velocity = newVelocity;
         }
-        else{
+        else
+        {
             VelocityComputed(newVelocity);
         }
     }


### PR DESCRIPTION
Adiciona a modificação para voltar ao Purrlamento quando não tiver nenhuma construção de coleta de recurso no mapa. Ainda falta acertar o recalcular rota. Talvez nem seja necessário, devo estudar o caso. 

## Mudança:

Apenas foi adicionado a checagem no começo da função:
```cs
    public Vector2 GetClosestResourceBuilding(Vector2 coords, string resource)
    {
        Vector2 closestBuildingPosition = default;

        **if (Ally.LevelManager.CatnipBuildings.Count == 0 &&
            Ally.LevelManager.SalmonBuildings.Count == 0 &&
            Ally.LevelManager.SandBuildings.Count == 0)
        {
            closestBuildingPosition = RecalculateCoords(Ally.GlobalPosition,
                Ally.LevelManager.Purrlament.GlobalPosition,
                true);

            return closestBuildingPosition;
        }**

        switch (resource)
        {
            case Constants.SALMON:
                foreach (var building in Ally.LevelManager.SalmonBuildings)
                {
                    closestBuildingPosition = GetClosestBuilding(coords, closestBuildingPosition, building);
                }

                break;
            case Constants.CATNIP:
                foreach (var building in Ally.LevelManager.CatnipBuildings)
                {
                    closestBuildingPosition = GetClosestBuilding(coords, closestBuildingPosition, building);
                }

                break;
            case Constants.SAND:
                foreach (var building in Ally.LevelManager.SandBuildings)
                {
                    closestBuildingPosition = GetClosestBuilding(coords, closestBuildingPosition, building);
                }

                break;
        }

        return closestBuildingPosition;
    }
```