### PR TITLE
53 - [BUG] Construção não sendo resetada apropriadamente

### DIFF
--- a/Resources/Buildings/GreatCommune/GreatCommune.tres
+++ b/Resources/Buildings/GreatCommune/GreatCommune.tres
@@ -1,11 +1,21 @@
-[gd_resource type="Resource" load_steps=3 format=3 uid="uid://byglexam8jwef"]
+[gd_resource type="Resource" load_steps=10 format=3 uid="uid://byglexam8jwef"]
 
+[ext_resource type="AudioStream" uid="uid://c6nf3cvt1mwmj" path="res://Assets/Audio/UI/ui-click-cancel.ogg" id="1_lgsbq"]
 [ext_resource type="Resource" uid="uid://dqintb8tp7i26" path="res://Resources/Buildings/GreatCommune/variation_01.tres" id="1_qa3rg"]
 [ext_resource type="Script" path="res://Scripts/Entities/Building/BuildingData.cs" id="1_r233n"]
+[ext_resource type="AudioStream" uid="uid://c11gv7w0q6nrn" path="res://Assets/Audio/SFX/Building/destroy-001.ogg" id="2_e8233"]
+[ext_resource type="AudioStream" uid="uid://bsh3gnwhsuydr" path="res://Assets/Audio/SFX/Building/destroy-002.ogg" id="3_ypyfg"]
+[ext_resource type="AudioStream" uid="uid://bd4t165n2t0s0" path="res://Assets/Audio/SFX/Building/destroy-003.ogg" id="4_qhf5g"]
+[ext_resource type="AudioStream" uid="uid://cnx6g6fuhlhlp" path="res://Assets/Audio/SFX/Building/destroy-004.ogg" id="5_p5u78"]
+[ext_resource type="AudioStream" uid="uid://cx71cf6ffwqvg" path="res://Assets/Audio/SFX/Building/destroy-005.ogg" id="6_y6oqf"]
+[ext_resource type="AudioStream" uid="uid://865i76f5bwrx" path="res://Assets/Audio/SFX/Building/plot.ogg" id="7_7m6ve"]
 
 [resource]
 resource_local_to_scene = true
 script = ExtResource("1_r233n")
+PlaceBuildingSound = ExtResource("7_7m6ve")
+DestroyBuildingSounds = [ExtResource("2_e8233"), ExtResource("3_ypyfg"), ExtResource("4_qhf5g"), ExtResource("5_p5u78"), ExtResource("6_y6oqf")]
+CancelSound = ExtResource("1_lgsbq")
 CatnipCost = 0
 Hp = 10000
 IsPreSpawned = true

--- a/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
@@ -22,8 +22,8 @@ public partial class EconomicState : AllyState
         }
 
         Ally.AllyIsBuilding = true;
-        Ally.ConstructionToBuild = building;
-        Ally.Navigation.SetTargetPosition(Ally.ConstructionToBuild.GlobalPosition);
+        Ally.InteractedBuilding = building;
+        Ally.Navigation.SetTargetPosition(Ally.InteractedBuilding.GlobalPosition);
         ChangeState("Move");
     }
 

--- a/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
@@ -4,6 +4,7 @@ public partial class Build : EconomicState
 {
     public override void Enter()
     {
+        Ally.ConstructionToBuild = Ally.InteractedBuilding;
         Ally.ConstructionToBuild.CurrentBuilders.Add(Ally);
         /*TODO
          TOCAR ANIMAÇÃO DE BUILD QUANDO TIVER*/
@@ -14,6 +15,8 @@ public partial class Build : EconomicState
     public override void Exit()
     {
         Ally.ConstructionToBuild.CurrentBuilders.Remove(Ally);
+        Ally.InteractedBuilding = null;
+        Ally.ConstructionToBuild = null;
         Ally.AllyIsBuilding = false;
     }
 

--- a/TSCN/Entities/Buildings/Building.tscn
+++ b/TSCN/Entities/Buildings/Building.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://d2xeg5t6t85er"]
 
 [ext_resource type="Script" path="res://Scripts/Entities/Building/Building.cs" id="1_pb7cr"]
-[ext_resource type="Texture2D" uid="uid://c6oakn300jtfm" path="res://Assets/Buildings/casa_comuna_001.png" id="2_q5vv2"]
+[ext_resource type="Texture2D" uid="uid://cvaqt5utn12w4" path="res://Assets/Buildings/casa_decor_001.png" id="2_qt8l0"]
 
 [node name="Building" type="Area2D" node_paths=PackedStringArray("BodyShape", "GridShape", "InteractionShape", "Sprite", "StaticBody", "Sounds")]
 y_sort_enabled = true
@@ -15,7 +15,7 @@ Sounds = NodePath("BuildingSounds")
 metadata/IsBuilding = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("2_q5vv2")
+texture = ExtResource("2_qt8l0")
 offset = Vector2(0, -32)
 region_rect = Rect2(8, 758, 114, 141)
 
@@ -27,9 +27,9 @@ region_rect = Rect2(8, 758, 114, 141)
 input_pickable = false
 
 [node name="Shape" type="CollisionPolygon2D" parent="GridArea"]
-polygon = PackedVector2Array(-128, 12, -8, 76, 144, 0, 16, -60)
+polygon = PackedVector2Array(-88, -24, 0, 24, 88, -24, 0, -72)
 
 [node name="InteractionShape" type="CollisionPolygon2D" parent="."]
-polygon = PackedVector2Array(-128, 12, -136, -44, 48, -140, 88, -96, 104, -104, 144, -60, 144, -4, -8, 76)
+polygon = PackedVector2Array(-80, -24, -80, -56, -48, -72, 48, -72, 80, -56, 80, -20, 32, -4, -8, 12)
 
 [node name="BuildingSounds" type="AudioStreamPlayer" parent="."]

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -1,42 +1,15 @@
-[gd_scene load_steps=16 format=4 uid="uid://c73kwxuuwdacc"]
+[gd_scene load_steps=7 format=4 uid="uid://c73kwxuuwdacc"]
 
 [ext_resource type="TileSet" uid="uid://c2nkgguv7dacf" path="res://Resources/Resources/Tileset.tres" id="1_pkymm"]
 [ext_resource type="PackedScene" uid="uid://dmqsbxvmpraew" path="res://TSCN/Systems/Camera.tscn" id="2_np81b"]
 [ext_resource type="PackedScene" uid="uid://d2xeg5t6t85er" path="res://TSCN/Entities/Buildings/Building.tscn" id="3_wt2d7"]
-[ext_resource type="AudioStream" uid="uid://c6nf3cvt1mwmj" path="res://Assets/Audio/UI/ui-click-cancel.ogg" id="4_pj8sw"]
-[ext_resource type="AudioStream" uid="uid://c11gv7w0q6nrn" path="res://Assets/Audio/SFX/Building/destroy-001.ogg" id="5_fp8b1"]
-[ext_resource type="AudioStream" uid="uid://bsh3gnwhsuydr" path="res://Assets/Audio/SFX/Building/destroy-002.ogg" id="6_abi55"]
-[ext_resource type="AudioStream" uid="uid://bd4t165n2t0s0" path="res://Assets/Audio/SFX/Building/destroy-003.ogg" id="7_dehce"]
-[ext_resource type="AudioStream" uid="uid://cnx6g6fuhlhlp" path="res://Assets/Audio/SFX/Building/destroy-004.ogg" id="8_x0uml"]
+[ext_resource type="Resource" uid="uid://byglexam8jwef" path="res://Resources/Buildings/GreatCommune/GreatCommune.tres" id="4_8lgn8"]
 [ext_resource type="PackedScene" uid="uid://d3gh4jmuicqic" path="res://TSCN/Entities/Characters/Allies/Economic/Economic.tscn" id="8_xv7v7"]
-[ext_resource type="AudioStream" uid="uid://cx71cf6ffwqvg" path="res://Assets/Audio/SFX/Building/destroy-005.ogg" id="9_jpkvd"]
-[ext_resource type="AudioStream" uid="uid://865i76f5bwrx" path="res://Assets/Audio/SFX/Building/plot.ogg" id="10_nikhm"]
-[ext_resource type="Resource" uid="uid://dqintb8tp7i26" path="res://Resources/Buildings/GreatCommune/variation_01.tres" id="11_iwbas"]
-[ext_resource type="Script" path="res://Scripts/Entities/Building/BuildingData.cs" id="12_uq78f"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_a5dn3"]
 vertices = PackedVector2Array(567.773, 1239.06, 567.047, 1239.48, 557.188, 1233.77, 900.469, 1048.94, 928.602, 1034.87, 678.813, 1176.22, 676.469, 1160.94, 662.352, 1167.99, 548.469, 695.063, 438.352, 640, 458, 630.18, 426, 153.82, 406.352, 143.992, 420.469, 136.938, 982, 262.18, 1001.64, 272, 982, 281.82, 982, 294.18, 1001.64, 304, 982, 313.82, 982, 326.18, 1001.64, 336, 982, 345.82, 982, 358.18, 1001.64, 368, 982, 377.82, 950, 502.18, 969.641, 512, 950, 521.82, 950, 534.18, 969.641, 544, 950, 553.82, -54, 681.82, 54, 662.18, 73.6406, 672, 54, 681.82, -54, 694.18, 726, 742.18, 745.641, 752, 726, 761.82, 586, 726.18, -192, 644.82, -219.531, 631.063, -265.648, 608, -251.531, 600.938, -214, 582.18, -160, 628.82, 891.531, 120.938, 905.641, 127.992, 886, 137.82, 955.531, 184.938, 969.641, 191.992, 950, 201.82, 987.531, 232.938, 1001.64, 239.992, 982, 249.82, 950, 214.18, 54, 694.18, 91.5313, 712.938, 105.641, 719.992, 86, 729.82, -22, 742.18, -22, 729.82, 86, 742.18, 123.531, 760.938, 137.641, 767.992, 118, 777.82, 10, 790.18, 10, 777.82, -214, 569.82, -233.641, 559.992, -219.531, 552.938, -182, 534.18, -182, 457.82, -201.641, 447.992, -187.531, 440.938, 982, 390.18, 1019.53, 408.938, 1033.65, 416, 1019.53, 423.063, 982, 441.82, -182, 521.82, -219.531, 503.063, -233.648, 496, -219.531, 488.938, -182, 470.18, 982, 454.18, 1001.64, 464, 987.531, 471.063, 950, 489.82, 950, 566.18, 969.641, 576, 955.531, 583.063, 795.531, 663.063, 586, 713.82, 758, 694.18, 777.641, 704, 763.531, 711.063, 726, 729.82, 182, 566.18, 201.641, 576, 187.531, 583.063, 91.5313, 631.063, 726, 774.18, 745.641, 784, 731.531, 791.063, 667.531, 823.063, 640, 836.82, 612.469, 823.063, 576, 804.82, 548.469, 744.938, 187.531, 871.063, 160, 884.82, 132.469, 871.063, 4.46875, 807.063, -9.64063, 800, 118, 790.18, 160, 811.18, 219.531, 855.063, -27.5313, 759.063, -41.6406, 752, -59.5313, 711.063, -73.6406, 704, 859.531, 104.938, 804.469, 104.938, 923.531, 168.938, -27.5313, 360.938, 484.469, 104.938, 416, 811.18, 452.469, 792.938, 539.531, 823.063, 475.531, 855.063, 448, 868.82, 416, 852.82, 352, 811.18, 384, 795.172, 384, 868.82, 352, 852.82, 288, 811.18, 320, 795.172, 319.992, 868.82, 292.469, 855.063, 256, 836.82, 224, 811.18, 256, 795.172, 192, 795.172, 32, 363.18, 54, 649.82, -91.5313, 663.063, -123.531, 647.063, 0, 347.172, 667.531, 104.938, 704, 123.18, 758, 681.82, 458, 617.82, 608, 107.18, 640, 91.1719, 182, 553.82, 68.4688, 344.938, 544, 107.18, 576, 91.1719, 736, 107.172, 768, 123.18, 511.992, 91.1719, 426, 166.18, 288, 532.82, 256, 548.82, 224, 532.82, 388.469, 184.938, 832, 91.1719, 886, 150.18, 420.469, 599.063, 324.469, 551.063)
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2), PackedInt32Array(3, 4, 5), PackedInt32Array(6, 3, 5), PackedInt32Array(6, 5, 7), PackedInt32Array(8, 9, 10), PackedInt32Array(11, 12, 13), PackedInt32Array(14, 15, 16), PackedInt32Array(17, 18, 19), PackedInt32Array(20, 21, 22), PackedInt32Array(23, 24, 25), PackedInt32Array(26, 27, 28), PackedInt32Array(29, 30, 31), PackedInt32Array(32, 33, 34, 35, 36), PackedInt32Array(37, 38, 39, 40), PackedInt32Array(41, 42, 43, 44, 45, 46), PackedInt32Array(47, 48, 49), PackedInt32Array(50, 51, 52), PackedInt32Array(53, 54, 55, 56), PackedInt32Array(57, 58, 59, 60, 61, 62), PackedInt32Array(63, 64, 65, 66, 67, 68), PackedInt32Array(69, 70, 71, 72), PackedInt32Array(73, 74, 75), PackedInt32Array(76, 77, 78, 79, 80), PackedInt32Array(81, 82, 83, 84, 85), PackedInt32Array(86, 87, 88, 89), PackedInt32Array(90, 91, 92, 93), PackedInt32Array(94, 95, 96, 97, 98, 40), PackedInt32Array(99, 100, 101, 102), PackedInt32Array(40, 103, 104, 105, 106, 107, 108, 109, 110), PackedInt32Array(111, 112, 113, 114, 115, 67, 116, 117, 118), PackedInt32Array(63, 68, 119, 120, 61, 60), PackedInt32Array(57, 62, 121, 122, 36, 35), PackedInt32Array(40, 98, 37), PackedInt32Array(123, 47, 49, 124), PackedInt32Array(125, 50, 52), PackedInt32Array(73, 75, 126), PackedInt32Array(11, 13, 127), PackedInt32Array(40, 39, 103), PackedInt32Array(128, 129, 110, 109, 130, 131, 132, 133), PackedInt32Array(134, 135, 128, 133, 136, 137), PackedInt32Array(138, 139, 134, 137, 140, 141, 142), PackedInt32Array(143, 144, 138, 142, 118), PackedInt32Array(145, 143, 118, 117), PackedInt32Array(66, 116, 67), PackedInt32Array(146, 147, 33, 32, 148, 149, 46, 72, 81, 126, 150), PackedInt32Array(31, 90, 93), PackedInt32Array(85, 73, 126), PackedInt32Array(29, 31, 93), PackedInt32Array(81, 85, 126), PackedInt32Array(151, 152, 153, 95, 94, 8, 10, 154, 155, 156), PackedInt32Array(157, 99, 102, 147, 146, 158), PackedInt32Array(159, 160, 155, 154), PackedInt32Array(152, 161, 162, 89, 26), PackedInt32Array(127, 163, 159, 154, 164, 11), PackedInt32Array(165, 166, 167, 168), PackedInt32Array(124, 169, 123), PackedInt32Array(124, 49, 170, 162), PackedInt32Array(152, 28, 29, 93, 153), PackedInt32Array(46, 45, 69, 72), PackedInt32Array(157, 158, 168, 167), PackedInt32Array(171, 172, 165, 168, 164, 154), PackedInt32Array(26, 28, 152), PackedInt32Array(86, 89, 162, 170, 80), PackedInt32Array(76, 80, 170), PackedInt32Array(25, 76, 170), PackedInt32Array(23, 25, 170), PackedInt32Array(22, 23, 170), PackedInt32Array(20, 22, 170), PackedInt32Array(19, 20, 170), PackedInt32Array(17, 19, 170, 125), PackedInt32Array(16, 17, 125, 56), PackedInt32Array(56, 55, 14), PackedInt32Array(125, 52, 56), PackedInt32Array(16, 56, 14)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(567, 1251, -696, 520, 688, -176, 1986, 448)])
-
-[sub_resource type="Resource" id="Resource_nxhfs"]
-resource_local_to_scene = true
-script = ExtResource("12_uq78f")
-PlaceBuildingSound = ExtResource("10_nikhm")
-DestroyBuildingSounds = [ExtResource("5_fp8b1"), ExtResource("6_abi55"), ExtResource("7_dehce"), ExtResource("8_x0uml"), ExtResource("9_jpkvd")]
-CancelSound = ExtResource("4_pj8sw")
-CatnipCost = 0
-Hp = 10000
-IsPreSpawned = true
-MaxProgress = 0
-Offset = Vector2(0, -32)
-ResourceType = ""
-SalmonCost = 0
-SandCost = 0
-Scale = Vector2(1, 1)
-Variations = Array[Resource]([ExtResource("11_iwbas")])
-TowerType = ""
-Type = "Commune"
 
 [node name="Level" type="Node2D"]
 y_sort_enabled = true
@@ -71,7 +44,7 @@ position = Vector2(576, 324)
 
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
-Data = SubResource("Resource_nxhfs")
+Data = ExtResource("4_8lgn8")
 IsPreSpawned = true
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]


### PR DESCRIPTION
- De acordo com o card #54 , não estava mudando apropriadamente para o novo comando (isso porque nem temos fila de comando ainda)

### Problema:
- Não estava resetando direito o InteractedBuilding e nem ConstructionToBuild dentro das variáveis de Ally, pois deveria torná-los null quando o aliado sai do estado Building para se mover.
- Quando clicava para iniciar uma nova construção, não fazia a mudança para o ConstructionToBuild novo, mantendo o antigo.

### Solução: 
- Apenas fazer esse reset apropriadamente.

Em **Build (ally state):**
![image](https://github.com/user-attachments/assets/e4e962bb-b701-4bcf-81b8-fb5793843c88)
![image](https://github.com/user-attachments/assets/680f660a-9628-4a8b-89c3-b79c388c7120)

Em **Economic state:**
![image](https://github.com/user-attachments/assets/d1f62e9c-53bb-46b8-89e7-8cb323bbae7e)
