### PR TITLE
62 - Bug da seleção de construção

### DIFF
--- a/Resources/Buildings/House/Structure.tres
+++ b/Resources/Buildings/House/Structure.tres
@@ -10,19 +10,19 @@
 segments = PackedVector2Array(-64, 4, 0, 36, 64, 8, 0, -24)
 
 [sub_resource type="ConcavePolygonShape2D" id="ConcavePolygonShape2D_onjix"]
-segments = PackedVector2Array(-64, 4, -64, -60, -24, -100, 40, -68, 64, -48, 56, -40, 56, 8, 0, 36)
+segments = PackedVector2Array(-53, 9, -53, -52, -11, -94, 49, -65, 80, -45, 72, -36, 73, 10, 7, 40)
 
 [sub_resource type="ConcavePolygonShape2D" id="ConcavePolygonShape2D_rcjts"]
 segments = PackedVector2Array(-64, 4, 0, 32, 64, 4, 0, -24)
 
 [sub_resource type="ConcavePolygonShape2D" id="ConcavePolygonShape2D_swenq"]
-segments = PackedVector2Array(-56, -44, -64, -52, -32, -72, 24, -96, 64, -56, 64, 4, 0, 32, -56, 4)
+segments = PackedVector2Array(-64, -48, -64, -52, -32, -72, 24, -96, 64, -56, 64, 8, 0, 36, -64, 4)
 
 [resource]
 script = ExtResource("3_s3kc4")
 PreviewTexture = ExtResource("2_vryfp")
 PlacedTexture = ExtResource("1_dwh80")
-PlacedOffset = Vector2(32, 16)
+PlacedOffset = Vector2(24, 12)
 Collision = SubResource("ConcavePolygonShape2D_dsicy")
 Interaction = SubResource("ConcavePolygonShape2D_onjix")
 RotatedPreviewTexture = ExtResource("1_2a4fv")

--- a/Scripts/Systems/Selectors.cs
+++ b/Scripts/Systems/Selectors.cs
@@ -18,14 +18,20 @@ public partial class Selectors : Node2D
         }
         else {
             foreach (var area in overlappingAreas) {
-                var isBuilding = area.GetParent().HasMeta(new StringName(BuildingData.PROP_ISBUILDING));
+                if (area is not Building)
+                {
+                    continue;
+                }
+                
                 var hasHigherY = area.GlobalPosition.Y > buildingInFront.GlobalPosition.Y;
-                if (hasHigherY && isBuilding) {
-                    buildingInFront = (Building)area.GetParent();
+                
+                if (hasHigherY)
+                {
+                    buildingInFront = (Building)area;
                 }
             }
         }
-
+        GD.Print("buildingInFront: ", buildingInFront.Name);
         return buildingInFront;
     }
 

--- a/Scripts/Systems/Selectors.cs
+++ b/Scripts/Systems/Selectors.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata.Ecma335;
 using Godot;
 using Godot.Collections;
 
@@ -9,12 +8,8 @@ public partial class Selectors : Node2D
     private static Building SelectTopBuilding(Array<Area2D> overlappingAreas)
     {
         var buildingInFront = new Building();
-        if (overlappingAreas.Count == 1) {
-            var isBuilding = overlappingAreas[0].HasMeta(new StringName(BuildingData.PROP_ISBUILDING));
-
-            if (isBuilding) {
-                buildingInFront = (Building)overlappingAreas[0];
-            }
+        if (overlappingAreas.Count == 1 && overlappingAreas[0] is Building) { 
+            buildingInFront = (Building)overlappingAreas[0];
         }
         else {
             foreach (var area in overlappingAreas) {

--- a/TSCN/Entities/Buildings/Building.tscn
+++ b/TSCN/Entities/Buildings/Building.tscn
@@ -16,7 +16,7 @@ metadata/IsBuilding = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("2_jbbtj")
-offset = Vector2(0, -32)
+offset = Vector2(24, -20)
 region_rect = Rect2(8, 758, 114, 141)
 
 [node name="NavigationBody" type="StaticBody2D" parent="."]
@@ -32,7 +32,6 @@ visible = false
 polygon = PackedVector2Array(-80, 8, -16, 40, 80, -8, 16, -40)
 
 [node name="InteractionShape" type="CollisionPolygon2D" parent="."]
-visible = false
-polygon = PackedVector2Array(-53, 9, -53, -52, -11, -94, 49, -65, 80, -45, 72, -36, 73, 10, 7, 40)
+polygon = PackedVector2Array(-61, 5, -61, -56, -19, -98, 49, -65, 70, -51, 64, -43, 64, 8, 0, 37)
 
 [node name="BuildingSounds" type="AudioStreamPlayer" parent="."]

--- a/TSCN/Entities/Buildings/Building.tscn
+++ b/TSCN/Entities/Buildings/Building.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://d2xeg5t6t85er"]
 
 [ext_resource type="Script" path="res://Scripts/Entities/Building/Building.cs" id="1_pb7cr"]
-[ext_resource type="Texture2D" uid="uid://bdiutwxamfcfe" path="res://Assets/Buildings/casa_vila_005_flip_build.png" id="2_djfw8"]
+[ext_resource type="Texture2D" uid="uid://cte2tclkdk3i3" path="res://Assets/Buildings/casa_vila_005.png" id="2_jbbtj"]
 
 [node name="Building" type="Area2D" node_paths=PackedStringArray("BodyShape", "GridShape", "InteractionShape", "Sprite", "StaticBody", "Sounds")]
 y_sort_enabled = true
@@ -15,7 +15,7 @@ Sounds = NodePath("BuildingSounds")
 metadata/IsBuilding = true
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("2_djfw8")
+texture = ExtResource("2_jbbtj")
 offset = Vector2(0, -32)
 region_rect = Rect2(8, 758, 114, 141)
 
@@ -32,6 +32,7 @@ visible = false
 polygon = PackedVector2Array(-80, 8, -16, 40, 80, -8, 16, -40)
 
 [node name="InteractionShape" type="CollisionPolygon2D" parent="."]
-polygon = PackedVector2Array(-56, -44, -64, -52, -32, -72, 24, -96, 64, -56, 64, 4, 0, 32, -56, 4)
+visible = false
+polygon = PackedVector2Array(-53, 9, -53, -52, -11, -94, 49, -65, 80, -45, 72, -36, 73, 10, 7, 40)
 
 [node name="BuildingSounds" type="AudioStreamPlayer" parent="."]

--- a/TSCN/Entities/Characters/Allies/Economic/Economic.tscn
+++ b/TSCN/Entities/Characters/Allies/Economic/Economic.tscn
@@ -104,7 +104,6 @@ frame_progress = 0.06364
 offset = Vector2(0, -24)
 
 [node name="InteractionShape" type="Area2D" parent="."]
-visible = false
 
 [node name="Shape" type="CollisionShape2D" parent="InteractionShape"]
 position = Vector2(0, -24)

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -22,7 +22,7 @@ vertices = PackedVector2Array(691.531, 124.938, 1401.65, 480, 724.211, 818.719, 
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3, 4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11, 12, 13), PackedInt32Array(14, 15, 13, 12, 16, 17), PackedInt32Array(18, 17, 16), PackedInt32Array(19, 20, 18, 16, 21, 22), PackedInt32Array(23, 24, 22, 21, 11, 25), PackedInt32Array(25, 11, 10)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(657, 1288, -889, 517, 540, -204, 2073, 584)])
 
-[sub_resource type="Resource" id="Resource_8aiw3"]
+[sub_resource type="Resource" id="Resource_y3fly"]
 resource_local_to_scene = true
 script = ExtResource("12_rx2l3")
 PlaceBuildingSound = ExtResource("10_82ayo")
@@ -72,7 +72,7 @@ position = Vector2(576, 324)
 
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
-Data = SubResource("Resource_8aiw3")
+Data = SubResource("Resource_y3fly")
 IsPreSpawned = true
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]


### PR DESCRIPTION
## **Problema**:
- #62 
Estava bugando na seleção de uma construção e não era quando estava próximo demais da borda e sim quando tinha uma outra Area2D dando overlap e tentava-se selecionar com o clique normal, gerando caixas de seleção quase infinitas por não conseguir completar o ciclo de código, ficando assim:

![image](https://github.com/user-attachments/assets/d1f1f5b6-2039-4f00-9ac2-b8d15667e8e9)

## **Solução:**
Na verdade tinha um erro grotesco no código. Ele tentava pegar por area.GetParent() pra tentar achar a construção, assim como é feito nos personagens. Só funcionava quando tinha apenas uma construção selecionada sem overlap porque a lógica é totalmente diferente, verifica só o único item que tem lá se ele possui a metadata. 

O problema é que as construções em si já são Area2D. Os personagens são CharacterBody com um InteractionShape que é uma Area2D. Para procurar personagens se eles são do tipo Ally ou algo assim faz sentido usar area.GetParent(), mas para construções não.

Nesse caso, corrigi a função pois ela é utilizada apenas para selecionar construções mesmo, então basta verificar a tipagem. Antes até mesmo estava utilizando metadata e complicando em excesso o código. Também removi essa parte.