### PR TITLE
64 - Bug cancelar construção move gato

### DIFF
--- a/Scripts/Entities/Characters/Allies/AllyState.cs
+++ b/Scripts/Entities/Characters/Allies/AllyState.cs
@@ -1,3 +1,4 @@
+using ClawtopiaCs.Scripts.Systems.GameModes;
 using Godot;
 
 public partial class AllyState : State
@@ -8,9 +9,10 @@ public partial class AllyState : State
     /// <summary>
     /// Inicializa dados pertinentes a unidades aliadas.
     /// </summary>
-    public void InitializeAlly(){
+    public void InitializeAlly() {
         Ally = (Ally) Unit;
         Controller = GetNode<Controller>("/root/Game/Controller");
+        SimulationMode.Singleton.AllyCommand += CommandReceived;
     }
     
     /// <summary>
@@ -20,15 +22,24 @@ public partial class AllyState : State
     /// Compara a distancia entre duas construções em relação a um ponto específico. Normalmente a posição atual da unidade.
     /// <returns><c>Vector2</c> Coordenadas globais.</returns>
     /// </summary>
-    public Vector2 GetClosestBuilding(Vector2 coords, Vector2 closestBuildingPosition, Building building){
-        // SE É A PRIMEIRA ITERACAO, RETORNA DIRETO
-        if (closestBuildingPosition == default){
+    public Vector2 GetClosestBuilding(Vector2 coords, Vector2 closestBuildingPosition, Building building) {
+        if (closestBuildingPosition == default) {
             return building.GlobalPosition;
         }
-        // SENAO, COMPARA DISTANCIA
-        if (closestBuildingPosition.DistanceSquaredTo(coords) > building.GlobalPosition.DistanceSquaredTo(coords)){
+
+        if (closestBuildingPosition.DistanceSquaredTo(coords) > building.GlobalPosition.DistanceSquaredTo(coords)) {
             return building.GlobalPosition;
         }
         return closestBuildingPosition;
+    }
+
+    public virtual void ChooseNextTargetPosition(Vector2 coords) {}
+
+    public override void CommandReceived(Vector2 coords)
+    {
+        if (!Ally.CurrentlySelected) { return; }
+
+        ChooseNextTargetPosition(coords);
+        ChangeState("Move");
     }
 }

--- a/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/EconomicState.cs
@@ -1,4 +1,5 @@
 using ClawtopiaCs.Scripts.Systems;
+using ClawtopiaCs.Scripts.Systems.GameModes;
 using Godot;
 using Godot.Collections;
 
@@ -11,9 +12,8 @@ public partial class EconomicState : AllyState
     {
         InitializeUnit();
         InitializeAlly();
-        BuildMode = ModeManager.GetNode<BuildMode>("BuildMode");
-        BuildMode.ConstructionStarted += BuildStarted;
-        BuildMode.BuildCompleted += BuildCompleted;
+        BuildMode.Singleton.ConstructionStarted += BuildStarted;
+        BuildMode.Singleton.BuildCompleted += BuildCompleted;
     }
 
     private void BuildStarted(Building building)
@@ -80,19 +80,19 @@ public partial class EconomicState : AllyState
         return closestBuildingPosition;
     }
 
-    public void ChooseNextTargetPosition(Vector2 coords)
+    public override void ChooseNextTargetPosition(Vector2 coords)
     {
         Vector2 nextTarget = coords;
         Ally.InteractedResource = null;
         Ally.InteractedBuilding = null;
-        Ally.InteractedWithBuilding = SimulationMode.BuildingsToInteract.Count > 0;
+        Ally.InteractedWithBuilding = SimulationMode.Singleton.BuildingsToInteract.Count > 0;
 
         if (Ally.InteractedWithBuilding)
         {
             nextTarget = RecalculateCoords(Ally.GlobalPosition,
-                SimulationMode.BuildingsToInteract[0].GlobalPosition);
+                SimulationMode.Singleton.BuildingsToInteract[0].GlobalPosition);
 
-            Ally.InteractedBuilding = SimulationMode.BuildingsToInteract[0];
+            Ally.InteractedBuilding = SimulationMode.Singleton.BuildingsToInteract[0];
         }
         else
         {

--- a/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Build.cs
@@ -1,3 +1,4 @@
+using ClawtopiaCs.Scripts.Systems.GameModes;
 using Godot;
 
 public partial class Build : EconomicState
@@ -20,15 +21,7 @@ public partial class Build : EconomicState
         Ally.AllyIsBuilding = false;
     }
 
-    public override void MouseRightClicked(Vector2 coords)
-    {
-        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
-            return;
-        }
-
-        ChooseNextTargetPosition(coords);
-        ChangeState("Move");
-    }
+    public override void CommandReceived(Vector2 coords) { }
 
     public override void NavigationFinished() { }
 }

--- a/Scripts/Entities/Characters/Allies/Economic/States/Collect.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Collect.cs
@@ -57,9 +57,9 @@ public partial class Collect : EconomicState
         }
     }
 
-    public override void MouseRightClicked(Vector2 coords)
+    public override void CommandReceived(Vector2 coords)
     {
-        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+        if (!Ally.CurrentlySelected) {
             return;
         }
 

--- a/Scripts/Entities/Characters/Allies/Economic/States/Idle.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Idle.cs
@@ -17,9 +17,9 @@ public partial class Idle : EconomicState
 
     public override void Exit() { }
 
-    public override void MouseRightClicked(Vector2 coords)
+    public override void CommandReceived(Vector2 coords)
     {
-        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode) {
+        if (!Ally.CurrentlySelected) {
             return;
         }
 

--- a/Scripts/Entities/Characters/Allies/Economic/States/Move.cs
+++ b/Scripts/Entities/Characters/Allies/Economic/States/Move.cs
@@ -14,9 +14,9 @@ public partial class Move : EconomicState
 
     public override void Exit() {}
 
-    public override void MouseRightClicked(Vector2 coords)
+    public override void CommandReceived(Vector2 coords)
     {
-        if (!Ally.CurrentlySelected || ModeManager.CurrentMode is BuildMode)
+        if (!Ally.CurrentlySelected)
         {
             return;
         }

--- a/Scripts/Entities/Characters/Allies/Military/States/MilitaryMove.cs
+++ b/Scripts/Entities/Characters/Allies/Military/States/MilitaryMove.cs
@@ -16,7 +16,7 @@ public partial class MilitaryMove : MilitaryState
     public override void Exit(){
     }
 
-    public override void MouseRightClicked(Vector2 coords){
+    public override void CommandReceived(Vector2 coords){
         if (!Ally.CurrentlySelected){ return; }
         Choose_next_target_position_MILITARY(coords);
     }

--- a/Scripts/Entities/Characters/State.cs
+++ b/Scripts/Entities/Characters/State.cs
@@ -7,24 +7,17 @@ public partial class State : Node
     [Signal]
     public delegate void StateTransitionEventHandler(State current, String next);
 
-    public BuildMode BuildMode;
-    public ModeManager ModeManager;
-    public SimulationMode SimulationMode;
-
-    // Referências recorrentes
     public Unit Unit;
 
-    // Funçôes recorrentes na maquina de estado
     public virtual void Enter() {}
 
     public virtual void Update(double delta) {}
 
     public virtual void Exit() {}
 
-    public virtual void MouseRightClicked(Vector2 coords) {}
-
     public virtual void NavigationFinished() {}
 
+    public virtual void CommandReceived(Vector2 coords) {}
 
     /// <summary>
     /// Inicializacao basica para todos os estados de qualquer unidade.
@@ -34,8 +27,6 @@ public partial class State : Node
     public void InitializeUnit()
     {
         Unit = GetParent().GetParent<Unit>();
-        ModeManager = GetNode<ModeManager>("/root/Game/ModeManager");
-        SimulationMode = ModeManager.GetNode<SimulationMode>("SimulationMode");
         Unit.Navigation.VelocityComputed += VelocityComputed;
     }
 
@@ -83,7 +74,9 @@ public partial class State : Node
 
         //newCoords.X += 100 * x;
         //newCoords.Y += 100 * y;
-        
+
+        //@TODO: Ver se isso eh realmente necessario porque talvez nao precise recalcular as coordenadas
+
         return buildingPosition;
     }
 

--- a/Scripts/Entities/Characters/StateMachine.cs
+++ b/Scripts/Entities/Characters/StateMachine.cs
@@ -1,11 +1,11 @@
 using Godot;
 using System;
 using Godot.Collections;
+using ClawtopiaCs.Scripts.Systems.GameModes;
 
 public partial class StateMachine : Node
 {
     public NavigationAgent2D Navigation;
-    public Controller Controller;
     
     public Dictionary States = new();
     public State CurrentState;
@@ -16,7 +16,6 @@ public partial class StateMachine : Node
     
     public override void _Ready(){
         Navigation = GetNode<NavigationAgent2D>("../Navigation");
-        Controller = GetNode<Controller>("/root/Game/Controller");
         Array<Node> nodeStates = GetChildren();
         foreach(var node in nodeStates){
             if (node is not State state){
@@ -29,7 +28,8 @@ public partial class StateMachine : Node
         }
         CurrentState = (State)States[DefaultState.Name];
         CurrentState.Enter();
-        Controller.MouseRightPressed += MouseRightClicked;
+
+        SimulationMode.Singleton.AllyCommand += CommandReceived;
         Navigation.NavigationFinished += NavigationFinished;
     }
 
@@ -51,8 +51,8 @@ public partial class StateMachine : Node
         InTransition = false;
     }
     
-    public void MouseRightClicked(Vector2 coords){
-        CurrentState.MouseRightClicked(coords);
+    public void CommandReceived(Vector2 coords){
+        CurrentState.CommandReceived(coords);
     }
 
     public void NavigationFinished(){

--- a/Scripts/Systems/Controller/Controller.cs
+++ b/Scripts/Systems/Controller/Controller.cs
@@ -27,12 +27,12 @@ public partial class Controller : Node
 
     public override void _UnhandledInput(InputEvent @event)
     {
-        var eventButton = @event as InputEventMouseButton;
-        var eventKey = @event as InputEventKey;
+        var eventButton = @event is InputEventMouseButton ? @event as InputEventMouseButton : null;
+        var eventKey = @event is InputEventKey ?@event as InputEventKey : null;
 
         if (NotHandledInput(@event)) { return; }
 
-        if (eventButton != null || eventKey != null) { 
+        if (eventButton != null) { 
             if (eventButton is { Pressed: true, ButtonIndex: MouseButton.Left })
             {
                 EmitSignal(SignalName.MousePressed, ModeManager.CurrentLevel.GetLocalMousePosition());
@@ -41,15 +41,18 @@ public partial class Controller : Node
             {
                 EmitSignal(SignalName.MouseReleased, ModeManager.CurrentLevel.GetLocalMousePosition());
             }
-            else if (eventButton is { DoubleClick: true, ButtonIndex: MouseButton.Left })
+            else if (eventButton is {  DoubleClick: true, ButtonIndex: MouseButton.Left })
             {
                 EmitSignal(SignalName.MouseDoubleClicked, ModeManager.CurrentLevel.GetLocalMousePosition());
             }
-            else if (eventButton is { Pressed: true or false, ButtonIndex: MouseButton.Right })
+            else if (eventButton is { Pressed: false, ButtonIndex: MouseButton.Right })
             {
                 EmitSignal(SignalName.MouseRightPressed, ModeManager.CurrentLevel.GetLocalMousePosition());
             }
-            else if (eventKey.Pressed && eventKey.Keycode == Key.R && ModeManager.CurrentMode is BuildMode)
+        } 
+        else if (eventKey != null)
+        {
+            if (eventKey.Pressed && eventKey.Keycode == Key.R)
             {
                 EmitSignal(SignalName.RotateBuilding);
             }

--- a/Scripts/Systems/GameModes/BuildMode.cs
+++ b/Scripts/Systems/GameModes/BuildMode.cs
@@ -7,6 +7,8 @@ using Godot.Collections;
 
 public partial class BuildMode : GameMode
 {
+    public static BuildMode Singleton { get; private set; }
+
     public string ResourceType;
 
     public Building CurrentBuilding;
@@ -20,6 +22,11 @@ public partial class BuildMode : GameMode
 
     public int TileSizeX = 64;
     public int TileSizeY = 32;
+
+    public override void _EnterTree()
+    {
+        Singleton = this;
+    }
 
     public override void _Ready()
     {

--- a/Scripts/Systems/GameModes/SimulationMode.cs
+++ b/Scripts/Systems/GameModes/SimulationMode.cs
@@ -6,6 +6,10 @@ namespace ClawtopiaCs.Scripts.Systems.GameModes;
 
 public partial class SimulationMode : GameMode
 {
+    [Signal] public delegate void AllyCommandEventHandler(Vector2 coords);
+
+    public static SimulationMode Singleton { get; private set; }
+
     public Array<Building> BuildingsToInteract = new();
     public TileMapLayer Bushes;
 
@@ -32,6 +36,11 @@ public partial class SimulationMode : GameMode
     public Vector2 StartingPoint;
     public SelectionBox VisualSelection;
     public TileMapLayer Water;
+
+    public override void _EnterTree()
+    {
+        Singleton = this;
+    }
 
     public override void _Ready()
     {
@@ -79,6 +88,13 @@ public partial class SimulationMode : GameMode
         var treatAsClick = VisualSelection.SelectionShape?.Size is { X: < 2, Y: < 2 };
         SelectEntities(treatAsClick, hasBuildings);
         Debug.Text = $"Selected Allies: {SelectedAllies.Count}";
+    }
+
+    public override void MouseRightPressed(Vector2 coords)
+    {
+        if (SelectedAllies.Count == 0) { return; }
+
+        EmitSignal(SignalName.AllyCommand, coords);
     }
 
     public void AboutToInteractWithBuilding(Building building)

--- a/Scripts/Systems/Selectors.cs
+++ b/Scripts/Systems/Selectors.cs
@@ -26,7 +26,6 @@ public partial class Selectors : Node2D
                 }
             }
         }
-        GD.Print("buildingInFront: ", buildingInFront.Name);
         return buildingInFront;
     }
 
@@ -176,7 +175,6 @@ public partial class Selectors : Node2D
             case Constants.CATNIP:
                 foreach (var item in LevelManager.Singleton.CollectPoints)
                 {
-                    GD.Print($"Catnip: {item}");
                     if (item is CatnipCollectPoint)
                     {
                         points.Add(item);

--- a/TSCN/Levels/Level-1.tscn
+++ b/TSCN/Levels/Level-1.tscn
@@ -22,7 +22,7 @@ vertices = PackedVector2Array(691.531, 124.938, 1401.65, 480, 724.211, 818.719, 
 polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3, 4, 5, 6, 7), PackedInt32Array(8, 9, 10, 11, 12, 13), PackedInt32Array(14, 15, 13, 12, 16, 17), PackedInt32Array(18, 17, 16), PackedInt32Array(19, 20, 18, 16, 21, 22), PackedInt32Array(23, 24, 22, 21, 11, 25), PackedInt32Array(25, 11, 10)])
 outlines = Array[PackedVector2Array]([PackedVector2Array(657, 1288, -889, 517, 540, -204, 2073, 584)])
 
-[sub_resource type="Resource" id="Resource_y3fly"]
+[sub_resource type="Resource" id="Resource_gbd35"]
 resource_local_to_scene = true
 script = ExtResource("12_rx2l3")
 PlaceBuildingSound = ExtResource("10_82ayo")
@@ -72,7 +72,7 @@ position = Vector2(576, 324)
 
 [node name="Purrlament" parent="." instance=ExtResource("3_wt2d7")]
 position = Vector2(576, 328)
-Data = SubResource("Resource_y3fly")
+Data = SubResource("Resource_gbd35")
 IsPreSpawned = true
 
 [node name="Economic" parent="." instance=ExtResource("8_xv7v7")]


### PR DESCRIPTION
## **Problema**:
- Contexto do problema: #64 
De fato estava sendo verificado se o CurrentMode era o SimulationMode (no caso, fazendo early return caso fosse BuildMode), mas isso não estava mais sendo suficiente depois que eu fiz alterações no Controller para poder lidar com teclas do teclado também (antes lidava só com mouse). 

Nesse trecho: **`else if (eventButton is { Pressed: true or false, ButtonIndex: MouseButton.Right })`** do código anterior estava verificando tanto no caso do botão pressionado quando do botão solto. Isso triggava o evento duas vezes, uma durante o BuildMode que cancelava a construção e automaticamente mudava para o SimulationMode e outra depois de ter mudado para o SimulationMode.

Isso causava então de ambos os comportamentos serem ativados.

## **Solução**:
Alguns passos: 
- Modifiquei um pouco o Controller para lidar com botão do mouse e tecla separadamente. 
- Apenas o SimulationMode é capaz de emitir comandos para personagens, via um novo Signal: **`AllyCommand`**
- A maquina de estado dos personagens agora responde a esse Signal novo em vez de responder diretamente ao **`MouseRightClicked`**
- Transformei todos os GameModes em Singleton, para facilitar, não precisa mais de tanta referência local no node que vai usar esses modos de jogo.
- Removi todas as referências locais para usar Singleton

Com isso, agora o aliado responde apenas ao sinal de AllyCommand e o único GameMode capaz de emitir esse sinal é o SimulationMode, agora eliminando verificação desnecessária e que não estava funcionando pra todos os casos. 

Sinto que dá pra melhorar o código agora, podemos criar uma lista de Comandos específicos e aí com base em cada comando e a coordenada, o aliado vai lá fazer a coisa. Atualmente verificamos com base em um monte de fatores. Algo a se pensar...